### PR TITLE
Webp migration command

### DIFF
--- a/app/Console/Commands/EncodeAndMoveMedia.php
+++ b/app/Console/Commands/EncodeAndMoveMedia.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\StoreImage;
+use App\Models\Page;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class EncodeAndMoveMedia extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'media:encode-and-move';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Encode image files to webp format and store them in a new S3 path, move all other files to same path.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        Page::whereNotNull('image_path')->chunk(200, function ($pages) {
+            foreach ($pages as $page) {
+                try {
+                    $imagePath = $page->image_path;
+                    $mediaPath = '';
+
+                    if (Str::startsWith(Storage::mimeType($imagePath), 'image/')) {
+                        if (! Str::endsWith($imagePath, '.webp')) {
+                            $filename = pathinfo($imagePath, PATHINFO_FILENAME);
+                            $mediaPath = 'books/'.$page->book->slug.'/'.$filename.'.webp';
+                            StoreImage::dispatch(Storage::disk('s3')->get($imagePath), $mediaPath);
+                        } else {
+                            $filename = pathinfo($imagePath, PATHINFO_EXTENSION);
+                            $mediaPath = 'books/'.$page->book->slug.'/'.$filename;
+                            Storage::disk('s3')->copy($imagePath, $mediaPath);
+                        }
+                    } elseif (Str::startsWith(Storage::mimeType($imagePath), 'video/')) {
+                        $filename = pathinfo($imagePath, PATHINFO_EXTENSION);
+                        $mediaPath = 'books/'.$page->book->slug.'/'.$filename;
+                        Storage::disk('s3')->copy($imagePath, $mediaPath);
+                    }
+
+                    if ($mediaPath) {
+                        $page->media_path = $mediaPath;
+                        $page->save();
+                    }
+                } catch (\Exception $e) {
+                    Log::error('Error processing file: '.$e->getMessage());
+                }
+            }
+        });
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
-use Illuminate\Support\Facades\Log;
 
 class PageController extends Controller
 {

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,5 +1,4 @@
 <?php
-use Illuminate\Support\Facades\Log;
 
 return [
 

--- a/database/migrations/2024_06_06_040241_add_media_path_to_pages_table.php
+++ b/database/migrations/2024_06_06_040241_add_media_path_to_pages_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->string('media_path')->after('image_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->dropColumn('media_path');
+        });
+    }
+};


### PR DESCRIPTION
this introduces a command that processes all image files that are not webp to webp for better performance, and moves all files to a new s3 path, 

A migration is included that creates a new column to save this new path , so the old path can be used if needed while verifying the images moved correctly

`php artisan media:encode-and-move`

resolves #10 

