### PR TITLE
point to media_path instead of image_path

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -141,7 +141,7 @@ class BookController extends Controller
     public function destroy(Book $book): Redirector|RedirectResponse|Application
     {
         foreach ($book->pages() as $page) {
-            Storage::disk('s3')->delete($page->image_path);
+            Storage::disk('s3')->delete($page->media_path);
         }
         $book->pages()->delete();
         $book->delete();

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -26,7 +26,7 @@ class Book extends Model
 
     public function coverImage(): BelongsTo
     {
-        return $this->belongsTo(Page::class, 'cover_page')->select('id', 'image_path');
+        return $this->belongsTo(Page::class, 'cover_page')->select('id', 'media_path');
     }
 
     public function category(): BelongsTo

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -14,12 +14,12 @@ class Page extends Model
 
     protected $fillable = [
         'content',
-        'image_path',
+        'media_path',
         'video_link',
         'book_id',
     ];
 
-    public function getImagePathAttribute($value): string
+    public function getMediaPathAttribute($value): string
     {
         if (Str::startsWith($value, 'https://') || empty($value)) {
             return $value;
@@ -34,9 +34,9 @@ class Page extends Model
 
     public function scopeHasImage($query)
     {
-        return $query->where('image_path', 'like', '%.jpg%')
-            ->orWhere('image_path', 'like', '%.png%')
-            ->orWhere('image_path', 'like', '%.webp%');
+        return $query->where('media_path', 'like', '%.jpg%')
+            ->orWhere('media_path', 'like', '%.png%')
+            ->orWhere('media_path', 'like', '%.webp%');
     }
 
     public function book(): BelongsTo

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -18,7 +18,7 @@ class PageFactory extends Factory
     {
         return [
             'content' => $this->faker->paragraphs(3, true),
-            'image_path' => $this->faker->imageUrl(),
+            'media_path' => $this->faker->imageUrl(),
         ];
     }
 }

--- a/database/seeders/BookSeeder.php
+++ b/database/seeders/BookSeeder.php
@@ -24,8 +24,8 @@ class BookSeeder extends Seeder
                 ->create()
                 ->each(function ($book) {
                     $page = $book->pages()
-                        ->whereNotNull('image_path')
-                        ->where('image_path', 'like', '%.png%')
+                        ->whereNotNull('media_path')
+                        ->where('media_path', 'like', '%.png%')
                         ->first();
 
                     if ($page) {

--- a/resources/js/Pages/Book/EditPageForm.vue
+++ b/resources/js/Pages/Book/EditPageForm.vue
@@ -29,7 +29,7 @@ const bookForm = useForm({
     cover_page: props.book.cover_page,
 });
 
-const imagePreview = ref(props.page.image_path);
+const imagePreview = ref(props.page.media_path);
 
 const imageInput = ref(null);
 const mediaOption = ref("upload"); // upload , link
@@ -218,9 +218,9 @@ const makeCoverPage = () => {
         </div>
         <div
             v-else-if="
-                page.image_path.includes('.jpg') ||
-                page.image_path.includes('.png') ||
-                page.image_path.includes('.webp')
+                page.media_path.includes('.jpg') ||
+                page.media_path.includes('.png') ||
+                page.media_path.includes('.webp')
             "
             class="flex justify-center mt-5 md:mt-10"
         >

--- a/resources/js/Pages/Book/Page.vue
+++ b/resources/js/Pages/Book/Page.vue
@@ -3,9 +3,9 @@
         class="rounded-lg overflow-hidden bg-gradient-to-r from-white dark:from-gray-700 dark:via-gray-900 to-yellow-100 dark:to-black flex flex-col justify-between"
     >
         <LazyLoader
-            v-if="page.image_path"
+            v-if="page.media_path"
             class="rounded-top max-h-[90vh] object-contain"
-            :src="page.image_path"
+            :src="page.media_path"
             :alt="page.description"
         />
         <div v-else-if="embedUrl" class="video-container">

--- a/resources/js/Pages/Book/Show.vue
+++ b/resources/js/Pages/Book/Show.vue
@@ -8,9 +8,9 @@
                 <div class="flex justify-between flex-wrap">
                     <div class="flex items-center">
                         <img
-                            v-if="book.cover_image?.image_path"
+                            v-if="book.cover_image?.media_path"
                             class="object-cover max-h-12 rounded mr-2"
-                            :src="book.cover_image.image_path"
+                            :src="book.cover_image.media_path"
                             alt="cover image"
                         />
                         <h2

--- a/resources/js/Pages/Books/BooksGrid.vue
+++ b/resources/js/Pages/Books/BooksGrid.vue
@@ -32,7 +32,7 @@
                 </div>
                 <div class="h-36">
                     <LazyLoader
-                        :src="book.cover_image?.image_path"
+                        :src="book.cover_image?.media_path"
                         :alt="`${book.title} cover image`"
                         :is-cover="true"
                     />

--- a/resources/js/Pages/Uploads/UploadsGrid.vue
+++ b/resources/js/Pages/Uploads/UploadsGrid.vue
@@ -78,9 +78,9 @@ function embedUrl(link) {
                     "
                 >
                     <LazyLoader
-                        v-if="photo.image_path"
+                        v-if="photo.media_path"
                         classes="rounded-top pointer-events-none"
-                        :src="photo.image_path"
+                        :src="photo.media_path"
                         :is-cover="true"
                     />
                     <div

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -77,7 +77,7 @@ class PagesTest extends TestCase
         Storage::disk('s3')->assertExists($filePath);
 
         $page = Book::find($book->id)->pages->first();
-        $this->assertSame($page->image_path, Storage::url($filePath));
+        $this->assertSame($page->media_path, Storage::url($filePath));
         $this->assertSame($page->content, $payload['content']);
 
         $response->assertRedirect(route('books.show', $book));
@@ -115,7 +115,7 @@ class PagesTest extends TestCase
 
         $freshPage = Page::where('book_id', $book->id)->first();
         $this->assertSame($freshPage->content, $payload['content']);
-        $this->assertSame($freshPage->image_path, Storage::url($filePath));
+        $this->assertSame($freshPage->media_path, Storage::url($filePath));
 
         $response->assertRedirect(route('books.show', $book));
     }
@@ -155,7 +155,7 @@ class PagesTest extends TestCase
         $page = $book->pages->first();
 
         $response = $this->delete(route('pages.destroy', $page));
-        Storage::disk('s3')->assertMissing($page->image_path);
+        Storage::disk('s3')->assertMissing($page->media_path);
 
         $this->assertNull(Page::find($page->id));
 


### PR DESCRIPTION
the intention of this PR is to point to the new `media_path` for all images and videos, if there are any issue this PR can be reverted back.
Once this is tested and works, we can make another pr to drop the `image_path` column and then delete the `book/` s3 bucket