### PR TITLE
Add World Clock page with multi-city clocks, timer, and clock-as-logo

### DIFF
--- a/app/Http/Controllers/WorldClockController.php
+++ b/app/Http/Controllers/WorldClockController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class WorldClockController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('WorldClock/Index', [
+            'defaultCities' => config('world_clock.default_cities'),
+            'maxCities' => config('world_clock.max_cities'),
+        ]);
+    }
+
+    public function searchCities(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'q' => ['required', 'string', 'min:2', 'max:100'],
+        ]);
+
+        $needle = mb_strtolower($validated['q']);
+
+        $results = collect(config('world_clock.cities'))
+            ->filter(fn (array $city) => str_contains(mb_strtolower($city['name']), $needle)
+                || str_contains(mb_strtolower($city['country'] ?? ''), $needle))
+            ->unique(fn (array $city) => $city['timezone'].'|'.$city['name'])
+            ->take(15)
+            ->values()
+            ->all();
+
+        return response()->json($results);
+    }
+}

--- a/config/world_clock.php
+++ b/config/world_clock.php
@@ -1,0 +1,181 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum clocks
+    |--------------------------------------------------------------------------
+    |
+    | The maximum number of city clocks a user may display at once on the
+    | World Clock page.
+    |
+    */
+
+    'max_cities' => 6,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default cities
+    |--------------------------------------------------------------------------
+    |
+    | Shown on first load so the page works with zero API calls. Each entry is
+    | ['name' => ..., 'timezone' => <IANA>, 'country' => ...].
+    |
+    */
+
+    'default_cities' => [
+        ['name' => 'New York', 'timezone' => 'America/New_York', 'country' => 'United States'],
+        ['name' => 'Los Angeles', 'timezone' => 'America/Los_Angeles', 'country' => 'United States'],
+        ['name' => 'London', 'timezone' => 'Europe/London', 'country' => 'United Kingdom'],
+        ['name' => 'Paris', 'timezone' => 'Europe/Paris', 'country' => 'France'],
+        ['name' => 'Tokyo', 'timezone' => 'Asia/Tokyo', 'country' => 'Japan'],
+        ['name' => 'Sydney', 'timezone' => 'Australia/Sydney', 'country' => 'Australia'],
+        ['name' => 'Dubai', 'timezone' => 'Asia/Dubai', 'country' => 'United Arab Emirates'],
+        ['name' => 'Mumbai', 'timezone' => 'Asia/Kolkata', 'country' => 'India'],
+        ['name' => 'São Paulo', 'timezone' => 'America/Sao_Paulo', 'country' => 'Brazil'],
+        ['name' => 'UTC', 'timezone' => 'UTC', 'country' => 'Coordinated Universal Time'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Searchable cities
+    |--------------------------------------------------------------------------
+    |
+    | Curated list backing the city search. Searched server-side by name or
+    | country so the feature works fully offline with no third-party API.
+    |
+    */
+
+    'cities' => [
+        // North America
+        ['name' => 'New York', 'timezone' => 'America/New_York', 'country' => 'United States'],
+        ['name' => 'Los Angeles', 'timezone' => 'America/Los_Angeles', 'country' => 'United States'],
+        ['name' => 'Chicago', 'timezone' => 'America/Chicago', 'country' => 'United States'],
+        ['name' => 'Denver', 'timezone' => 'America/Denver', 'country' => 'United States'],
+        ['name' => 'Phoenix', 'timezone' => 'America/Phoenix', 'country' => 'United States'],
+        ['name' => 'Houston', 'timezone' => 'America/Chicago', 'country' => 'United States'],
+        ['name' => 'Seattle', 'timezone' => 'America/Los_Angeles', 'country' => 'United States'],
+        ['name' => 'San Francisco', 'timezone' => 'America/Los_Angeles', 'country' => 'United States'],
+        ['name' => 'Miami', 'timezone' => 'America/New_York', 'country' => 'United States'],
+        ['name' => 'Boston', 'timezone' => 'America/New_York', 'country' => 'United States'],
+        ['name' => 'Washington', 'timezone' => 'America/New_York', 'country' => 'United States'],
+        ['name' => 'Atlanta', 'timezone' => 'America/New_York', 'country' => 'United States'],
+        ['name' => 'Anchorage', 'timezone' => 'America/Anchorage', 'country' => 'United States'],
+        ['name' => 'Honolulu', 'timezone' => 'Pacific/Honolulu', 'country' => 'United States'],
+        ['name' => 'Toronto', 'timezone' => 'America/Toronto', 'country' => 'Canada'],
+        ['name' => 'Vancouver', 'timezone' => 'America/Vancouver', 'country' => 'Canada'],
+        ['name' => 'Montreal', 'timezone' => 'America/Toronto', 'country' => 'Canada'],
+        ['name' => 'Calgary', 'timezone' => 'America/Edmonton', 'country' => 'Canada'],
+        ['name' => 'Mexico City', 'timezone' => 'America/Mexico_City', 'country' => 'Mexico'],
+        ['name' => 'Guadalajara', 'timezone' => 'America/Mexico_City', 'country' => 'Mexico'],
+        ['name' => 'Havana', 'timezone' => 'America/Havana', 'country' => 'Cuba'],
+        ['name' => 'Panama City', 'timezone' => 'America/Panama', 'country' => 'Panama'],
+        ['name' => 'Guatemala City', 'timezone' => 'America/Guatemala', 'country' => 'Guatemala'],
+
+        // South America
+        ['name' => 'São Paulo', 'timezone' => 'America/Sao_Paulo', 'country' => 'Brazil'],
+        ['name' => 'Rio de Janeiro', 'timezone' => 'America/Sao_Paulo', 'country' => 'Brazil'],
+        ['name' => 'Buenos Aires', 'timezone' => 'America/Argentina/Buenos_Aires', 'country' => 'Argentina'],
+        ['name' => 'Santiago', 'timezone' => 'America/Santiago', 'country' => 'Chile'],
+        ['name' => 'Lima', 'timezone' => 'America/Lima', 'country' => 'Peru'],
+        ['name' => 'Bogotá', 'timezone' => 'America/Bogota', 'country' => 'Colombia'],
+        ['name' => 'Caracas', 'timezone' => 'America/Caracas', 'country' => 'Venezuela'],
+        ['name' => 'Quito', 'timezone' => 'America/Guayaquil', 'country' => 'Ecuador'],
+        ['name' => 'La Paz', 'timezone' => 'America/La_Paz', 'country' => 'Bolivia'],
+        ['name' => 'Montevideo', 'timezone' => 'America/Montevideo', 'country' => 'Uruguay'],
+
+        // Europe
+        ['name' => 'London', 'timezone' => 'Europe/London', 'country' => 'United Kingdom'],
+        ['name' => 'Dublin', 'timezone' => 'Europe/Dublin', 'country' => 'Ireland'],
+        ['name' => 'Paris', 'timezone' => 'Europe/Paris', 'country' => 'France'],
+        ['name' => 'Madrid', 'timezone' => 'Europe/Madrid', 'country' => 'Spain'],
+        ['name' => 'Barcelona', 'timezone' => 'Europe/Madrid', 'country' => 'Spain'],
+        ['name' => 'Lisbon', 'timezone' => 'Europe/Lisbon', 'country' => 'Portugal'],
+        ['name' => 'Berlin', 'timezone' => 'Europe/Berlin', 'country' => 'Germany'],
+        ['name' => 'Munich', 'timezone' => 'Europe/Berlin', 'country' => 'Germany'],
+        ['name' => 'Frankfurt', 'timezone' => 'Europe/Berlin', 'country' => 'Germany'],
+        ['name' => 'Amsterdam', 'timezone' => 'Europe/Amsterdam', 'country' => 'Netherlands'],
+        ['name' => 'Brussels', 'timezone' => 'Europe/Brussels', 'country' => 'Belgium'],
+        ['name' => 'Zurich', 'timezone' => 'Europe/Zurich', 'country' => 'Switzerland'],
+        ['name' => 'Geneva', 'timezone' => 'Europe/Zurich', 'country' => 'Switzerland'],
+        ['name' => 'Rome', 'timezone' => 'Europe/Rome', 'country' => 'Italy'],
+        ['name' => 'Milan', 'timezone' => 'Europe/Rome', 'country' => 'Italy'],
+        ['name' => 'Vienna', 'timezone' => 'Europe/Vienna', 'country' => 'Austria'],
+        ['name' => 'Prague', 'timezone' => 'Europe/Prague', 'country' => 'Czechia'],
+        ['name' => 'Warsaw', 'timezone' => 'Europe/Warsaw', 'country' => 'Poland'],
+        ['name' => 'Budapest', 'timezone' => 'Europe/Budapest', 'country' => 'Hungary'],
+        ['name' => 'Stockholm', 'timezone' => 'Europe/Stockholm', 'country' => 'Sweden'],
+        ['name' => 'Oslo', 'timezone' => 'Europe/Oslo', 'country' => 'Norway'],
+        ['name' => 'Copenhagen', 'timezone' => 'Europe/Copenhagen', 'country' => 'Denmark'],
+        ['name' => 'Helsinki', 'timezone' => 'Europe/Helsinki', 'country' => 'Finland'],
+        ['name' => 'Athens', 'timezone' => 'Europe/Athens', 'country' => 'Greece'],
+        ['name' => 'Istanbul', 'timezone' => 'Europe/Istanbul', 'country' => 'Turkey'],
+        ['name' => 'Moscow', 'timezone' => 'Europe/Moscow', 'country' => 'Russia'],
+        ['name' => 'Kyiv', 'timezone' => 'Europe/Kyiv', 'country' => 'Ukraine'],
+        ['name' => 'Bucharest', 'timezone' => 'Europe/Bucharest', 'country' => 'Romania'],
+        ['name' => 'Reykjavik', 'timezone' => 'Atlantic/Reykjavik', 'country' => 'Iceland'],
+
+        // Africa
+        ['name' => 'Cairo', 'timezone' => 'Africa/Cairo', 'country' => 'Egypt'],
+        ['name' => 'Lagos', 'timezone' => 'Africa/Lagos', 'country' => 'Nigeria'],
+        ['name' => 'Nairobi', 'timezone' => 'Africa/Nairobi', 'country' => 'Kenya'],
+        ['name' => 'Johannesburg', 'timezone' => 'Africa/Johannesburg', 'country' => 'South Africa'],
+        ['name' => 'Cape Town', 'timezone' => 'Africa/Johannesburg', 'country' => 'South Africa'],
+        ['name' => 'Casablanca', 'timezone' => 'Africa/Casablanca', 'country' => 'Morocco'],
+        ['name' => 'Accra', 'timezone' => 'Africa/Accra', 'country' => 'Ghana'],
+        ['name' => 'Addis Ababa', 'timezone' => 'Africa/Addis_Ababa', 'country' => 'Ethiopia'],
+        ['name' => 'Tunis', 'timezone' => 'Africa/Tunis', 'country' => 'Tunisia'],
+        ['name' => 'Algiers', 'timezone' => 'Africa/Algiers', 'country' => 'Algeria'],
+
+        // Middle East
+        ['name' => 'Dubai', 'timezone' => 'Asia/Dubai', 'country' => 'United Arab Emirates'],
+        ['name' => 'Abu Dhabi', 'timezone' => 'Asia/Dubai', 'country' => 'United Arab Emirates'],
+        ['name' => 'Riyadh', 'timezone' => 'Asia/Riyadh', 'country' => 'Saudi Arabia'],
+        ['name' => 'Doha', 'timezone' => 'Asia/Qatar', 'country' => 'Qatar'],
+        ['name' => 'Tel Aviv', 'timezone' => 'Asia/Jerusalem', 'country' => 'Israel'],
+        ['name' => 'Jerusalem', 'timezone' => 'Asia/Jerusalem', 'country' => 'Israel'],
+        ['name' => 'Tehran', 'timezone' => 'Asia/Tehran', 'country' => 'Iran'],
+        ['name' => 'Baghdad', 'timezone' => 'Asia/Baghdad', 'country' => 'Iraq'],
+        ['name' => 'Beirut', 'timezone' => 'Asia/Beirut', 'country' => 'Lebanon'],
+        ['name' => 'Amman', 'timezone' => 'Asia/Amman', 'country' => 'Jordan'],
+
+        // Asia
+        ['name' => 'Mumbai', 'timezone' => 'Asia/Kolkata', 'country' => 'India'],
+        ['name' => 'Delhi', 'timezone' => 'Asia/Kolkata', 'country' => 'India'],
+        ['name' => 'Bengaluru', 'timezone' => 'Asia/Kolkata', 'country' => 'India'],
+        ['name' => 'Kolkata', 'timezone' => 'Asia/Kolkata', 'country' => 'India'],
+        ['name' => 'Karachi', 'timezone' => 'Asia/Karachi', 'country' => 'Pakistan'],
+        ['name' => 'Dhaka', 'timezone' => 'Asia/Dhaka', 'country' => 'Bangladesh'],
+        ['name' => 'Colombo', 'timezone' => 'Asia/Colombo', 'country' => 'Sri Lanka'],
+        ['name' => 'Kathmandu', 'timezone' => 'Asia/Kathmandu', 'country' => 'Nepal'],
+        ['name' => 'Bangkok', 'timezone' => 'Asia/Bangkok', 'country' => 'Thailand'],
+        ['name' => 'Hanoi', 'timezone' => 'Asia/Ho_Chi_Minh', 'country' => 'Vietnam'],
+        ['name' => 'Ho Chi Minh City', 'timezone' => 'Asia/Ho_Chi_Minh', 'country' => 'Vietnam'],
+        ['name' => 'Jakarta', 'timezone' => 'Asia/Jakarta', 'country' => 'Indonesia'],
+        ['name' => 'Kuala Lumpur', 'timezone' => 'Asia/Kuala_Lumpur', 'country' => 'Malaysia'],
+        ['name' => 'Singapore', 'timezone' => 'Asia/Singapore', 'country' => 'Singapore'],
+        ['name' => 'Manila', 'timezone' => 'Asia/Manila', 'country' => 'Philippines'],
+        ['name' => 'Hong Kong', 'timezone' => 'Asia/Hong_Kong', 'country' => 'Hong Kong'],
+        ['name' => 'Beijing', 'timezone' => 'Asia/Shanghai', 'country' => 'China'],
+        ['name' => 'Shanghai', 'timezone' => 'Asia/Shanghai', 'country' => 'China'],
+        ['name' => 'Taipei', 'timezone' => 'Asia/Taipei', 'country' => 'Taiwan'],
+        ['name' => 'Seoul', 'timezone' => 'Asia/Seoul', 'country' => 'South Korea'],
+        ['name' => 'Tokyo', 'timezone' => 'Asia/Tokyo', 'country' => 'Japan'],
+        ['name' => 'Osaka', 'timezone' => 'Asia/Tokyo', 'country' => 'Japan'],
+
+        // Oceania
+        ['name' => 'Sydney', 'timezone' => 'Australia/Sydney', 'country' => 'Australia'],
+        ['name' => 'Melbourne', 'timezone' => 'Australia/Melbourne', 'country' => 'Australia'],
+        ['name' => 'Brisbane', 'timezone' => 'Australia/Brisbane', 'country' => 'Australia'],
+        ['name' => 'Perth', 'timezone' => 'Australia/Perth', 'country' => 'Australia'],
+        ['name' => 'Adelaide', 'timezone' => 'Australia/Adelaide', 'country' => 'Australia'],
+        ['name' => 'Auckland', 'timezone' => 'Pacific/Auckland', 'country' => 'New Zealand'],
+        ['name' => 'Wellington', 'timezone' => 'Pacific/Auckland', 'country' => 'New Zealand'],
+        ['name' => 'Fiji', 'timezone' => 'Pacific/Fiji', 'country' => 'Fiji'],
+
+        // Reference
+        ['name' => 'UTC', 'timezone' => 'UTC', 'country' => 'Coordinated Universal Time'],
+    ],
+
+];

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,6 +1,63 @@
 @tailwind base;
 @tailwind components;
 
+/* World Clock face palette — follows the app theme (data-theme on <html>) and
+   dark mode (.dark on <html>) so the "Theme" clock face matches the site. */
+:root {
+  --wc-face: #fffdf5;
+  --wc-rim: #1d4ed8;
+  --wc-tick: #1f2937;
+  --wc-tick-minor: #9ca3af;
+  --wc-numeral: #1f2937;
+  --wc-hand: #111827;
+  --wc-second: #dc2626;
+  --wc-cap: #111827;
+}
+
+.dark {
+  --wc-face: #1f2937;
+  --wc-rim: #6366f1;
+  --wc-tick: #e5e7eb;
+  --wc-tick-minor: #6b7280;
+  --wc-numeral: #f3f4f6;
+  --wc-hand: #f9fafb;
+  --wc-second: #fbbf24;
+  --wc-cap: #f9fafb;
+}
+
+[data-theme="christmas"] {
+  --wc-face: #f8f8ff;
+  --wc-rim: #ffd700;
+  --wc-tick: #165b33;
+  --wc-tick-minor: #2d5a27;
+  --wc-numeral: #be0b31;
+  --wc-hand: #165b33;
+  --wc-second: #d42426;
+  --wc-cap: #ffd700;
+}
+
+[data-theme="halloween"] {
+  --wc-face: #2b1b3d;
+  --wc-rim: #ff7518;
+  --wc-tick: #ff8c42;
+  --wc-tick-minor: #6b2d8f;
+  --wc-numeral: #ff6600;
+  --wc-hand: #f5f5f5;
+  --wc-second: #ff6600;
+  --wc-cap: #ff7518;
+}
+
+[data-theme="fireworks"] {
+  --wc-face: #0f172a;
+  --wc-rim: #ef4444;
+  --wc-tick: #e2e8f0;
+  --wc-tick-minor: #475569;
+  --wc-numeral: #f8fafc;
+  --wc-hand: #f8fafc;
+  --wc-second: #3b82f6;
+  --wc-cap: #ef4444;
+}
+
 @layer utilities {
   /* Text Colors */
   .text-theme-title {

--- a/resources/js/Components/ApplicationLogo.vue
+++ b/resources/js/Components/ApplicationLogo.vue
@@ -3,7 +3,7 @@
         v-if="logo.enabled && logo.timezone"
         :timezone="logo.timezone"
         :city-name="logo.cityName"
-        :size="56"
+        size="100%"
         :face-preset="logo.facePreset"
         :hand-preset="logo.handPreset"
         :numerals="logo.numerals"

--- a/resources/js/Components/ApplicationLogo.vue
+++ b/resources/js/Components/ApplicationLogo.vue
@@ -1,5 +1,17 @@
 <template>
+    <AnalogClock
+        v-if="logo.enabled && logo.timezone"
+        :timezone="logo.timezone"
+        :city-name="logo.cityName"
+        :size="56"
+        :face-preset="logo.facePreset"
+        :hand-preset="logo.handPreset"
+        :numerals="logo.numerals"
+        :show-seconds="true"
+        second-hand-mode="tick"
+    />
     <svg
+        v-else
         width="100%"
         height="100%"
         viewBox="0 0 200 200"
@@ -616,6 +628,8 @@
 </template>
 
 <script setup>
+import AnalogClock from "@/Components/WorldClock/AnalogClock.vue";
+import { useLogoPreference } from "@/composables/useLogoPreference";
 import { usePage } from "@inertiajs/vue3";
 import { computed } from "vue";
 
@@ -623,4 +637,6 @@ const page = usePage();
 const isChristmas = computed(() => page.props.theme === "christmas");
 const isJuly = computed(() => page.props.theme === "fireworks");
 const isHalloween = computed(() => page.props.theme === "halloween");
+
+const { logo } = useLogoPreference();
 </script>

--- a/resources/js/Components/Modal.vue
+++ b/resources/js/Components/Modal.vue
@@ -68,8 +68,8 @@ const maxWidthClass = computed(() => {
     <teleport to="body">
         <transition leave-active-class="duration-200">
             <div
-                ref="scrollRoot"
                 v-show="show"
+                ref="scrollRoot"
                 data-modal-scroll-root
                 class="fixed inset-0 z-50 overflow-y-auto"
                 scroll-region

--- a/resources/js/Components/WorldClock/AnalogClock.test.js
+++ b/resources/js/Components/WorldClock/AnalogClock.test.js
@@ -1,0 +1,86 @@
+import AnalogClock from "@/Components/WorldClock/AnalogClock.vue";
+import { useGlobalTimer } from "@/composables/useGlobalTimer";
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it } from "vitest";
+
+const timer = useGlobalTimer();
+
+describe("Components/WorldClock/AnalogClock.vue", () => {
+  it("renders Roman numerals when numerals='roman'", () => {
+    const wrapper = mount(AnalogClock, {
+      props: { timezone: "UTC", numerals: "roman" }
+    });
+    const text = wrapper.text();
+    expect(text).toContain("XII");
+    expect(text).toContain("IV");
+    expect(text).toContain("IX");
+  });
+
+  it("renders Arabic numerals when numerals='arabic'", () => {
+    const wrapper = mount(AnalogClock, {
+      props: { timezone: "UTC", numerals: "arabic" }
+    });
+    expect(wrapper.text()).toContain("12");
+    expect(wrapper.text()).toContain("3");
+  });
+
+  it("renders no numerals when numerals='none'", () => {
+    const wrapper = mount(AnalogClock, {
+      props: { timezone: "UTC", numerals: "none" }
+    });
+    expect(wrapper.findAll("text").length).toBe(0);
+  });
+
+  it("applies rotation transforms to the hands", () => {
+    const wrapper = mount(AnalogClock, {
+      props: { timezone: "UTC" }
+    });
+    const rotated = wrapper
+      .findAll("g")
+      .filter((g) => (g.attributes("transform") || "").includes("rotate("));
+    // hour, minute and second hands
+    expect(rotated.length).toBe(3);
+  });
+
+  it("hides the second hand when showSeconds is false", () => {
+    const wrapper = mount(AnalogClock, {
+      props: { timezone: "UTC", showSeconds: false }
+    });
+    const rotated = wrapper
+      .findAll("g")
+      .filter((g) => (g.attributes("transform") || "").includes("rotate("));
+    expect(rotated.length).toBe(2);
+  });
+
+  afterEach(() => timer.stop());
+
+  it("renders no timer wedge when the global timer is inactive", () => {
+    timer.stop();
+    const wrapper = mount(AnalogClock, { props: { timezone: "UTC" } });
+    expect(wrapper.findAll('[fill="#b91c1c"]').length).toBe(0);
+  });
+
+  it("renders a partial deep-red wedge (path) for a fractional timer", () => {
+    timer.start(15 * 60);
+    const wrapper = mount(AnalogClock, { props: { timezone: "UTC" } });
+    const wedges = wrapper.findAll('[fill="#b91c1c"]');
+    expect(wedges.length).toBe(1);
+    expect(wedges[0].element.tagName.toLowerCase()).toBe("path");
+  });
+
+  it("renders a full deep-red disk (circle) when the timer fills the hour", () => {
+    timer.start(60 * 60);
+    const wrapper = mount(AnalogClock, { props: { timezone: "UTC" } });
+    const wedges = wrapper.findAll('[fill="#b91c1c"]');
+    expect(wedges.length).toBe(1);
+    expect(wedges[0].element.tagName.toLowerCase()).toBe("circle");
+  });
+
+  it("gives each clock a unique gradient id", () => {
+    const props = { timezone: "UTC", facePreset: "night" }; // 'night' has a gradient
+    const id1 = mount(AnalogClock, { props }).find("radialGradient").attributes("id");
+    const id2 = mount(AnalogClock, { props }).find("radialGradient").attributes("id");
+    expect(id1).toBeTruthy();
+    expect(id1).not.toBe(id2);
+  });
+});

--- a/resources/js/Components/WorldClock/AnalogClock.vue
+++ b/resources/js/Components/WorldClock/AnalogClock.vue
@@ -1,0 +1,231 @@
+<script>
+// Module-scoped so every AnalogClock instance gets a distinct id (the gradient
+// def id must be unique across all clocks on the page).
+let uidCounter = 0;
+</script>
+
+<script setup>
+import { useClockTime } from "@/composables/useClockTime";
+import { useGlobalTimer } from "@/composables/useGlobalTimer";
+import { getFacePreset } from "@/world-clock/presets/faces";
+import { getHandPreset } from "@/world-clock/presets/hands";
+import { computed, toRef } from "vue";
+
+const props = defineProps({
+  timezone: { type: String, required: true },
+  cityName: { type: String, default: "" },
+  size: { type: Number, default: 280 },
+  facePreset: { type: String, default: "classic" },
+  handPreset: { type: String, default: "classic" },
+  numerals: { type: String, default: "arabic" }, // 'arabic' | 'roman' | 'none'
+  showSeconds: { type: Boolean, default: true },
+  secondHandMode: { type: String, default: "smooth" } // 'smooth' | 'tick'
+});
+
+// Fixed deep-red countdown pie, shared by every clock via the global timer.
+// Drawn before the ticks/numerals/hands so they stay visible on top.
+const TIMER_COLOR = "#b91c1c";
+const { active: timerActive, fraction: timerFraction } = useGlobalTimer();
+
+// Unique id so multiple clocks don't collide on gradient defs.
+const uid = `wc-${(uidCounter += 1)}`;
+
+const face = computed(() => getFacePreset(props.facePreset));
+const hand = computed(() => getHandPreset(props.handPreset));
+const numeralStyle = computed(() => props.numerals || face.value.numerals);
+
+const CENTER = 50;
+const { hours, minutes, seconds, milliseconds } = useClockTime(
+  toRef(props, "timezone")
+);
+
+// Time-timer pie: a wedge from 12 o'clock spanning the remaining time, which
+// shrinks back toward 12 as the countdown runs. Maps to the 60-minute dial.
+const TIMER_RADIUS = 44;
+const timerWedge = computed(() => {
+  if (!timerActive.value) return null;
+  const f = Math.max(0, Math.min(1, timerFraction.value));
+  if (f <= 0) return null;
+  if (f >= 1) return { full: true };
+  const angle = f * 360;
+  const rad = ((angle - 90) * Math.PI) / 180;
+  const endX = CENTER + TIMER_RADIUS * Math.cos(rad);
+  const endY = CENTER + TIMER_RADIUS * Math.sin(rad);
+  const largeArc = angle > 180 ? 1 : 0;
+  return {
+    full: false,
+    d: `M ${CENTER} ${CENTER} L ${CENTER} ${CENTER - TIMER_RADIUS} A ${TIMER_RADIUS} ${TIMER_RADIUS} 0 ${largeArc} 1 ${endX} ${endY} Z`
+  };
+});
+
+const hourAngle = computed(() => (hours.value % 12) * 30);
+const minuteAngle = computed(() => minutes.value * 6 + seconds.value * 0.1);
+const secondAngle = computed(() => {
+  const s =
+    props.secondHandMode === "smooth"
+      ? seconds.value + milliseconds.value / 1000
+      : seconds.value;
+  return s * 6;
+});
+
+// 60 tick marks; every 5th is a major tick.
+const ticks = computed(() => {
+  const marks = [];
+  for (let i = 0; i < 60; i += 1) {
+    const isMajor = i % 5 === 0;
+    if (!isMajor && !face.value.showMinorTicks) continue;
+    const angle = (i * 6 * Math.PI) / 180;
+    const sin = Math.sin(angle);
+    const cos = -Math.cos(angle);
+    const outer = 47;
+    const inner = isMajor ? 39 : 43;
+    marks.push({
+      key: i,
+      x1: CENTER + sin * outer,
+      y1: CENTER + cos * outer,
+      x2: CENTER + sin * inner,
+      y2: CENTER + cos * inner,
+      color: isMajor ? face.value.tickColor : face.value.tickMinorColor,
+      width: isMajor ? 1.4 : 0.6
+    });
+  }
+  return marks;
+});
+
+const ROMAN = [
+  "XII",
+  "I",
+  "II",
+  "III",
+  "IV",
+  "V",
+  "VI",
+  "VII",
+  "VIII",
+  "IX",
+  "X",
+  "XI"
+];
+
+const numeralLabels = computed(() => {
+  if (numeralStyle.value === "none") return [];
+  const radius = 37;
+  return Array.from({ length: 12 }, (_, idx) => {
+    const hour = idx === 0 ? 12 : idx;
+    const angle = (idx * 30 * Math.PI) / 180;
+    return {
+      key: idx,
+      x: CENTER + Math.sin(angle) * radius,
+      y: CENTER - Math.cos(angle) * radius,
+      label: numeralStyle.value === "roman" ? ROMAN[idx] : String(hour)
+    };
+  });
+});
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 100 100"
+    role="img"
+    :aria-label="cityName ? `Clock for ${cityName}` : 'Analog clock'"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <radialGradient
+        v-if="face.gradient"
+        :id="`${uid}-grad`"
+        cx="50%"
+        cy="45%"
+        r="60%"
+      >
+        <stop offset="0%" :stop-color="face.gradient[0]" />
+        <stop offset="100%" :stop-color="face.gradient[1]" />
+      </radialGradient>
+    </defs>
+
+    <!-- Face background -->
+    <circle
+      :cx="CENTER"
+      :cy="CENTER"
+      r="48"
+      :fill="face.gradient ? `url(#${uid}-grad)` : face.faceFill"
+    />
+
+    <!-- Countdown timer pie (shared, always deep red) -->
+    <template v-if="timerWedge">
+      <circle
+        v-if="timerWedge.full"
+        :cx="CENTER"
+        :cy="CENTER"
+        :r="TIMER_RADIUS"
+        :fill="TIMER_COLOR"
+      />
+      <path v-else :d="timerWedge.d" :fill="TIMER_COLOR" />
+    </template>
+
+    <!-- Rim -->
+    <circle
+      :cx="CENTER"
+      :cy="CENTER"
+      r="48"
+      fill="none"
+      :stroke="face.rimColor"
+      :stroke-width="face.rimWidth"
+    />
+
+    <!-- Tick marks -->
+    <line
+      v-for="tick in ticks"
+      :key="`tick-${tick.key}`"
+      :x1="tick.x1"
+      :y1="tick.y1"
+      :x2="tick.x2"
+      :y2="tick.y2"
+      :stroke="tick.color"
+      :stroke-width="tick.width"
+      stroke-linecap="round"
+    />
+
+    <!-- Numerals -->
+    <text
+      v-for="numeral in numeralLabels"
+      :key="`num-${numeral.key}`"
+      :x="numeral.x"
+      :y="numeral.y"
+      text-anchor="middle"
+      dominant-baseline="central"
+      :fill="face.numeralColor"
+      :font-family="face.numeralFont"
+      font-size="9"
+      font-weight="600"
+      class="wc-numeral"
+    >
+      {{ numeral.label }}
+    </text>
+
+    <!-- Hands -->
+    <g :transform="`translate(${CENTER} ${CENTER}) rotate(${hourAngle})`">
+      <path :d="hand.hour" :fill="face.handColor" />
+    </g>
+    <g :transform="`translate(${CENTER} ${CENTER}) rotate(${minuteAngle})`">
+      <path :d="hand.minute" :fill="face.handColor" />
+    </g>
+    <g
+      v-if="showSeconds"
+      :transform="`translate(${CENTER} ${CENTER}) rotate(${secondAngle})`"
+    >
+      <path :d="hand.second" :fill="face.secondColor" />
+    </g>
+
+    <!-- Center cap -->
+    <circle :cx="CENTER" :cy="CENTER" r="2.6" :fill="face.capColor" />
+  </svg>
+</template>
+
+<style scoped>
+.wc-numeral {
+  user-select: none;
+}
+</style>

--- a/resources/js/Components/WorldClock/AnalogClock.vue
+++ b/resources/js/Components/WorldClock/AnalogClock.vue
@@ -14,7 +14,7 @@ import { computed, toRef } from "vue";
 const props = defineProps({
   timezone: { type: String, required: true },
   cityName: { type: String, default: "" },
-  size: { type: Number, default: 280 },
+  size: { type: [Number, String], default: 280 },
   facePreset: { type: String, default: "classic" },
   handPreset: { type: String, default: "classic" },
   numerals: { type: String, default: "arabic" }, // 'arabic' | 'roman' | 'none'

--- a/resources/js/Components/WorldClock/CityPicker.vue
+++ b/resources/js/Components/WorldClock/CityPicker.vue
@@ -1,0 +1,132 @@
+<script setup>
+/* global route */
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+
+const props = defineProps({
+  selectedCities: { type: Array, default: () => [] },
+  maxCities: { type: Number, default: 6 }
+});
+
+const emit = defineEmits(["add", "remove"]);
+
+const query = ref("");
+const results = ref([]);
+const isLoading = ref(false);
+const errorMessage = ref("");
+let debounceTimer = null;
+// Sequence token so an out-of-order (stale) response can't clobber a newer one.
+let searchSeq = 0;
+
+const atLimit = computed(() => props.selectedCities.length >= props.maxCities);
+
+const isSelected = (city) =>
+  props.selectedCities.some(
+    (c) => c.timezone === city.timezone && c.name === city.name
+  );
+
+const runSearch = async (term) => {
+  const seq = (searchSeq += 1);
+  isLoading.value = true;
+  errorMessage.value = "";
+  try {
+    const response = await window.axios.get(
+      route("world-clock.cities.search"),
+      { params: { q: term } }
+    );
+    if (seq !== searchSeq) return;
+    results.value = Array.isArray(response.data) ? response.data : [];
+  } catch {
+    if (seq !== searchSeq) return;
+    results.value = [];
+    errorMessage.value = "Unable to search cities right now.";
+  } finally {
+    if (seq === searchSeq) isLoading.value = false;
+  }
+};
+
+watch(query, (value) => {
+  clearTimeout(debounceTimer);
+  const term = value.trim();
+  if (term.length < 2) {
+    results.value = [];
+    isLoading.value = false;
+    return;
+  }
+  debounceTimer = setTimeout(() => runSearch(term), 300);
+});
+
+onBeforeUnmount(() => clearTimeout(debounceTimer));
+
+const onAdd = (city) => {
+  if (atLimit.value || isSelected(city)) return;
+  emit("add", city);
+};
+</script>
+
+<template>
+  <div class="rounded-lg bg-gray-800 p-4">
+    <h3 class="font-heading text-lg text-gray-100">Cities</h3>
+    <p class="mt-1 text-xs text-gray-400">
+      {{ selectedCities.length }} / {{ maxCities }} selected
+    </p>
+
+    <div class="mt-3">
+      <input
+        v-model="query"
+        type="search"
+        placeholder="Search a city or country…"
+        class="w-full rounded-md border-gray-600 bg-gray-900 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:ring-indigo-500"
+      />
+    </div>
+
+    <p v-if="atLimit" class="mt-2 text-xs text-amber-400">
+      Maximum of {{ maxCities }} clocks reached. Remove one to add another.
+    </p>
+    <p v-if="errorMessage" class="mt-2 text-xs text-red-400">
+      {{ errorMessage }}
+    </p>
+
+    <ul v-if="isLoading" class="mt-3 text-sm text-gray-400">
+      <li>Searching…</li>
+    </ul>
+    <ul v-else-if="results.length" class="mt-3 space-y-1">
+      <li v-for="city in results" :key="`${city.timezone}-${city.name}`">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm text-gray-100 transition-colors hover:bg-gray-700 disabled:opacity-40"
+          :disabled="atLimit || isSelected(city)"
+          @click="onAdd(city)"
+        >
+          <span>
+            {{ city.name }}
+            <span class="text-gray-400">· {{ city.country }}</span>
+          </span>
+          <i
+            v-if="isSelected(city)"
+            class="ri-check-line text-green-400"
+            aria-hidden="true"
+          ></i>
+          <i v-else class="ri-add-line text-gray-400" aria-hidden="true"></i>
+        </button>
+      </li>
+    </ul>
+
+    <div class="mt-4 flex flex-wrap gap-2">
+      <span
+        v-for="city in selectedCities"
+        :key="`chip-${city.timezone}-${city.name}`"
+        class="inline-flex items-center gap-1 rounded-full bg-gray-700 px-3 py-1 text-xs text-gray-100"
+      >
+        {{ city.name }}
+        <button
+          type="button"
+          class="text-gray-400 hover:text-red-400"
+          :aria-label="`Remove ${city.name}`"
+          @click="emit('remove', city)"
+        >
+          <i class="ri-close-line" aria-hidden="true"></i>
+        </button>
+      </span>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/WorldClock/ClockCard.test.js
+++ b/resources/js/Components/WorldClock/ClockCard.test.js
@@ -1,0 +1,46 @@
+import ClockCard from "@/Components/WorldClock/ClockCard.vue";
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+describe("Components/WorldClock/ClockCard.vue", () => {
+  let wrapper = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Unmount so the shared clock tick releases its subscriber and the next
+    // mount re-reads the (faked) system time.
+    if (wrapper) wrapper.unmount();
+    wrapper = null;
+    vi.useRealTimers();
+  });
+
+  const mountAt = async (isoInstant, timezone) => {
+    vi.setSystemTime(new Date(isoInstant));
+    wrapper = mount(ClockCard, {
+      props: { city: { name: "Testville", timezone } }
+    });
+    // The clock tick fires in onMounted; flush so the DOM reflects it.
+    await nextTick();
+    return wrapper;
+  };
+
+  it("prints the time in 12-hour format with a period (PM)", async () => {
+    await mountAt("2024-01-15T15:05:00Z", "UTC");
+    expect(wrapper.text()).toContain("3:05 PM");
+  });
+
+  it("prints the time in 12-hour format (AM, midnight as 12)", async () => {
+    await mountAt("2024-01-15T00:30:00Z", "UTC");
+    expect(wrapper.text()).toContain("12:30 AM");
+  });
+
+  it("speaks the city and 12-hour time", async () => {
+    await mountAt("2024-01-15T15:05:00Z", "UTC");
+    await wrapper.find('[aria-label="Say the time in Testville"]').trigger("click");
+    expect(wrapper.emitted("speak")?.[0]?.[0]).toBe("Testville, 3:05 PM");
+  });
+});

--- a/resources/js/Components/WorldClock/ClockCard.vue
+++ b/resources/js/Components/WorldClock/ClockCard.vue
@@ -1,0 +1,97 @@
+<script setup>
+import AnalogClock from "@/Components/WorldClock/AnalogClock.vue";
+import SpeakButton from "@/Components/SpeakButton.vue";
+import { useClockTime } from "@/composables/useClockTime";
+import { useLogoPreference } from "@/composables/useLogoPreference";
+import { computed, toRef } from "vue";
+
+const props = defineProps({
+  city: { type: Object, required: true },
+  size: { type: Number, default: 220 },
+  facePreset: { type: String, default: "classic" },
+  handPreset: { type: String, default: "classic" },
+  numerals: { type: String, default: "arabic" },
+  secondHandMode: { type: String, default: "smooth" }
+});
+
+const emit = defineEmits(["speak"]);
+
+const { logo, setLogoClock } = useLogoPreference();
+
+const isLogo = computed(
+  () =>
+    logo.enabled &&
+    logo.timezone === props.city.timezone &&
+    logo.cityName === props.city.name
+);
+
+const setAsLogo = () => {
+  setLogoClock({
+    cityName: props.city.name,
+    timezone: props.city.timezone,
+    facePreset: props.facePreset,
+    handPreset: props.handPreset,
+    numerals: props.numerals
+  });
+  emit("speak", `${props.city.name} clock set as the app logo`);
+};
+
+const { hour24, minutes } = useClockTime(toRef(() => props.city.timezone));
+
+// 12-hour clock time, e.g. "3:05 PM".
+const clockTime = computed(() => {
+  const period = hour24.value < 12 ? "AM" : "PM";
+  let h12 = hour24.value % 12;
+  if (h12 === 0) h12 = 12;
+  const m = String(minutes.value).padStart(2, "0");
+  return `${h12}:${m} ${period}`;
+});
+
+const digital = computed(() => clockTime.value);
+
+// City + local time spoken in 12-hour format, e.g. "Tokyo, 3:05 PM".
+const spokenTime = computed(() => `${props.city.name}, ${clockTime.value}`);
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-2">
+    <AnalogClock
+      :timezone="city.timezone"
+      :city-name="city.name"
+      :size="size"
+      :face-preset="facePreset"
+      :hand-preset="handPreset"
+      :numerals="numerals"
+      :second-hand-mode="secondHandMode"
+    />
+    <div class="text-center">
+      <div class="font-heading text-lg text-gray-100">{{ city.name }}</div>
+      <div class="text-sm text-gray-400">{{ digital }}</div>
+    </div>
+    <div class="flex items-center gap-2">
+      <SpeakButton
+        :aria-label="`Say the time in ${city.name}`"
+        @click="emit('speak', spokenTime)"
+      />
+      <button
+        type="button"
+        class="btn-bulge inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-full border p-2.5 shadow-sm transition-colors duration-150 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
+        :class="
+          isLogo
+            ? 'border-theme-button-active bg-theme-button-active text-theme-button-active'
+            : 'border-theme-primary bg-theme-primary text-theme-button hover:bg-theme-button hover:text-theme-button-hover'
+        "
+        :aria-pressed="isLogo"
+        :aria-label="`Use the ${city.name} clock as the app logo`"
+        :title="`Use the ${city.name} clock as the app logo`"
+        @click="setAsLogo"
+      >
+        <i
+          :class="isLogo ? 'ri-pushpin-fill' : 'ri-pushpin-line'"
+          class="text-xl"
+          aria-hidden="true"
+        ></i>
+      </button>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/WorldClock/ClockCard.vue
+++ b/resources/js/Components/WorldClock/ClockCard.vue
@@ -3,7 +3,7 @@ import AnalogClock from "@/Components/WorldClock/AnalogClock.vue";
 import SpeakButton from "@/Components/SpeakButton.vue";
 import { useClockTime } from "@/composables/useClockTime";
 import { useLogoPreference } from "@/composables/useLogoPreference";
-import { computed, toRef } from "vue";
+import { computed } from "vue";
 
 const props = defineProps({
   city: { type: Object, required: true },
@@ -36,7 +36,7 @@ const setAsLogo = () => {
   emit("speak", `${props.city.name} clock set as the app logo`);
 };
 
-const { hour24, minutes } = useClockTime(toRef(() => props.city.timezone));
+const { hour24, minutes } = useClockTime(computed(() => props.city.timezone));
 
 // 12-hour clock time, e.g. "3:05 PM".
 const clockTime = computed(() => {

--- a/resources/js/Components/WorldClock/ClockCustomizer.vue
+++ b/resources/js/Components/WorldClock/ClockCustomizer.vue
@@ -1,0 +1,186 @@
+<script setup>
+import SecondaryButton from "@/Components/SecondaryButton.vue";
+import SpeakButton from "@/Components/SpeakButton.vue";
+import { useGlobalTimer } from "@/composables/useGlobalTimer";
+import { useLogoPreference } from "@/composables/useLogoPreference";
+import { useSpeechSynthesis } from "@/composables/useSpeechSynthesis";
+import { FACE_OPTIONS } from "@/world-clock/presets/faces";
+import { HAND_OPTIONS } from "@/world-clock/presets/hands";
+import { computed } from "vue";
+
+const props = defineProps({
+  facePreset: { type: String, required: true },
+  handPreset: { type: String, required: true },
+  numerals: { type: String, required: true },
+  secondHandMode: { type: String, required: true }
+});
+
+const emit = defineEmits([
+  "update:facePreset",
+  "update:handPreset",
+  "update:numerals",
+  "update:secondHandMode"
+]);
+
+const { speak } = useSpeechSynthesis();
+const { logo, clearLogoClock } = useLogoPreference();
+const {
+  active: timerActive,
+  remainingSeconds,
+  start: startTimer,
+  stop: stopTimer
+} = useGlobalTimer();
+
+const TIMER_OPTIONS = [15, 30, 45, 60];
+
+const startTimerMinutes = (minutes) => {
+  startTimer(minutes * 60);
+  speak(`${minutes} minute timer started`);
+};
+
+const cancelTimer = () => {
+  stopTimer();
+  speak("Timer stopped");
+};
+
+const timerLabel = computed(() => {
+  const total = remainingSeconds.value;
+  const mm = Math.floor(total / 60);
+  const ss = total % 60;
+  return `${mm}:${String(ss).padStart(2, "0")}`;
+});
+
+const spokenRemaining = computed(() => {
+  const total = remainingSeconds.value;
+  const mm = Math.floor(total / 60);
+  const ss = total % 60;
+  const parts = [];
+  if (mm > 0) parts.push(`${mm} minute${mm === 1 ? "" : "s"}`);
+  if (ss > 0) parts.push(`${ss} second${ss === 1 ? "" : "s"}`);
+  if (parts.length === 0) parts.push("0 seconds");
+  return `${parts.join(" and ")} left`;
+});
+
+const NUMERAL_OPTIONS = [
+  { value: "arabic", label: "Arabic", speech: "Arabic numbers" },
+  { value: "roman", label: "Roman", speech: "Roman numerals" },
+  { value: "none", label: "None", speech: "No numbers" }
+];
+
+const SECOND_OPTIONS = [
+  { value: "smooth", label: "Smooth", speech: "Smooth second hand" },
+  { value: "tick", label: "Tick", speech: "Ticking second hand" }
+];
+
+// Each settings group renders as a row of large, tap-friendly buttons.
+const groups = computed(() => [
+  {
+    key: "facePreset",
+    title: "Clock face",
+    value: props.facePreset,
+    options: FACE_OPTIONS.map((o) => ({ ...o, speech: `${o.label} face` }))
+  },
+  {
+    key: "handPreset",
+    title: "Hands",
+    value: props.handPreset,
+    options: HAND_OPTIONS.map((o) => ({ ...o, speech: `${o.label} hands` }))
+  },
+  {
+    key: "numerals",
+    title: "Numbers",
+    value: props.numerals,
+    options: NUMERAL_OPTIONS
+  },
+  {
+    key: "secondHandMode",
+    title: "Second hand",
+    value: props.secondHandMode,
+    options: SECOND_OPTIONS
+  }
+]);
+
+const pick = (group, option) => {
+  emit(`update:${group.key}`, option.value);
+  speak(option.speech || option.label);
+};
+
+const resetLogo = () => {
+  clearLogoClock();
+  speak("Default logo restored");
+};
+</script>
+
+<template>
+  <div class="space-y-5 rounded-lg bg-gray-800 p-4">
+    <h3 class="font-heading text-lg text-gray-100">Customize</h3>
+
+    <div v-for="group in groups" :key="group.key">
+      <span class="text-sm text-gray-300">{{ group.title }}</span>
+      <div class="mt-2 flex flex-wrap gap-2">
+        <button
+          v-for="option in group.options"
+          :key="`${group.key}-${option.value}`"
+          type="button"
+          class="btn-bulge min-h-12 rounded-lg px-4 py-3 text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
+          :class="
+            group.value === option.value
+              ? 'bg-theme-button-active text-theme-button-active'
+              : 'bg-gray-700 text-gray-100 hover:bg-gray-600'
+          "
+          :aria-pressed="group.value === option.value"
+          @click="pick(group, option)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+
+    <div class="border-t border-gray-700 pt-4">
+      <span class="text-sm text-gray-300">Timer</span>
+      <p class="mt-1 text-xs text-gray-500">
+        A red countdown fills every clock and counts down on the face.
+      </p>
+      <div v-if="timerActive" class="mt-2 flex items-center gap-2">
+        <span
+          class="font-heading text-xl tabular-nums text-red-400"
+          aria-live="polite"
+        >
+          {{ timerLabel }}
+        </span>
+        <SpeakButton
+          aria-label="Say how much time is left"
+          @click="speak(spokenRemaining)"
+        />
+        <SecondaryButton @click="cancelTimer">Stop</SecondaryButton>
+      </div>
+      <div v-else class="mt-2 flex flex-wrap gap-2">
+        <button
+          v-for="minutes in TIMER_OPTIONS"
+          :key="`timer-${minutes}`"
+          type="button"
+          class="btn-bulge min-h-12 rounded-lg bg-gray-700 px-4 py-3 text-base font-semibold text-gray-100 transition-colors hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
+          :aria-label="`Start a ${minutes} minute timer`"
+          @click="startTimerMinutes(minutes)"
+        >
+          {{ minutes }} min
+        </button>
+      </div>
+    </div>
+
+    <div class="border-t border-gray-700 pt-4">
+      <span class="text-sm text-gray-300">App logo</span>
+      <p v-if="logo.enabled" class="mt-1 text-xs text-gray-400">
+        Logo: {{ logo.cityName || "Custom clock" }}. Use the pin button on a
+        clock to change it.
+      </p>
+      <p v-else class="mt-1 text-xs text-gray-500">
+        Use the pin button on a clock to set it as the app logo.
+      </p>
+
+      <SecondaryButton v-if="logo.enabled" class="mt-3" @click="resetLogo">
+        Reset to default logo
+      </SecondaryButton>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/WorldClock/WorldClockGrid.vue
+++ b/resources/js/Components/WorldClock/WorldClockGrid.vue
@@ -1,0 +1,35 @@
+<script setup>
+import ClockCard from "@/Components/WorldClock/ClockCard.vue";
+import { useSpeechSynthesis } from "@/composables/useSpeechSynthesis";
+
+const { speak } = useSpeechSynthesis();
+
+defineProps({
+  cities: { type: Array, default: () => [] },
+  facePreset: { type: String, default: "classic" },
+  handPreset: { type: String, default: "classic" },
+  numerals: { type: String, default: "arabic" },
+  secondHandMode: { type: String, default: "smooth" }
+});
+</script>
+
+<template>
+  <div
+    v-if="cities.length"
+    class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3"
+  >
+    <ClockCard
+      v-for="city in cities"
+      :key="`${city.timezone}-${city.name}`"
+      :city="city"
+      :face-preset="facePreset"
+      :hand-preset="handPreset"
+      :numerals="numerals"
+      :second-hand-mode="secondHandMode"
+      @speak="speak"
+    />
+  </div>
+  <p v-else class="text-center text-gray-400">
+    Add a city to see its clock.
+  </p>
+</template>

--- a/resources/js/Layouts/Nav/MobileMoreSheet.vue
+++ b/resources/js/Layouts/Nav/MobileMoreSheet.vue
@@ -36,8 +36,8 @@ const emit = defineEmits(["close"]);
     <button
       type="button"
       class="absolute inset-0 bg-gray-950/60"
-      @click="emit('close')"
       aria-label="Close more menu"
+      @click="emit('close')"
     ></button>
 
     <section
@@ -49,8 +49,8 @@ const emit = defineEmits(["close"]);
         <button
           type="button"
           class="inline-flex min-h-12 min-w-12 items-center justify-center rounded-lg border border-gray-600 text-white transition hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-200"
-          @click="emit('close')"
           aria-label="Close more menu"
+          @click="emit('close')"
         >
           <i class="ri-close-line text-2xl" aria-hidden="true"></i>
         </button>

--- a/resources/js/Layouts/Nav/Navigation.vue
+++ b/resources/js/Layouts/Nav/Navigation.vue
@@ -53,6 +53,12 @@ const topNavItems = computed(() => {
       href: route("movie-cast.index"),
       active: route().current("movie-cast.*"),
       icon: "ri-film-line"
+    },
+    {
+      label: "World Clock",
+      href: route("world-clock.index"),
+      active: route().current("world-clock.*"),
+      icon: "ri-time-line"
     }
   ];
 
@@ -109,6 +115,12 @@ const secondaryMobilePageItems = computed(() => {
       href: route("movie-cast.index"),
       active: route().current("movie-cast.*"),
       icon: "ri-film-line"
+    },
+    {
+      label: "World Clock",
+      href: route("world-clock.index"),
+      active: route().current("world-clock.*"),
+      icon: "ri-time-line"
     }
   ];
 

--- a/resources/js/Pages/Sounds/Index.vue
+++ b/resources/js/Pages/Sounds/Index.vue
@@ -374,7 +374,7 @@ onBeforeUnmount(() => {
                         MP3, WAV, OGG, and AAC (non-M4A) uploads are converted to M4A (AAC) for consistent playback (including Safari/iOS).
                     </div>
 
-                    <form @submit.prevent="submitUpload" class="space-y-4">
+                    <form class="space-y-4" @submit.prevent="submitUpload">
                         <div>
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                 Title <span class="text-red-500">*</span>
@@ -455,7 +455,7 @@ onBeforeUnmount(() => {
                         Edit Sound
                     </h3>
 
-                    <form @submit.prevent="submitEdit" class="space-y-4">
+                    <form class="space-y-4" @submit.prevent="submitEdit">
                         <div>
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                 Title <span class="text-red-500">*</span>

--- a/resources/js/Pages/WorldClock/Index.vue
+++ b/resources/js/Pages/WorldClock/Index.vue
@@ -1,0 +1,77 @@
+<script setup>
+import Accordion from "@/Components/Accordion.vue";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import CityPicker from "@/Components/WorldClock/CityPicker.vue";
+import ClockCustomizer from "@/Components/WorldClock/ClockCustomizer.vue";
+import WorldClockGrid from "@/Components/WorldClock/WorldClockGrid.vue";
+import { useWorldClockPreferences } from "@/composables/useWorldClockPreferences";
+import { Head } from "@inertiajs/vue3";
+
+const props = defineProps({
+  defaultCities: { type: Array, default: () => [] },
+  maxCities: { type: Number, default: 6 }
+});
+
+const { prefs, addCity, removeCity } = useWorldClockPreferences(
+  props.defaultCities,
+  props.maxCities
+);
+
+// Settings start expanded on desktop and collapsed on mobile, so phones lead
+// with the clocks themselves.
+const settingsOpen =
+  typeof window !== "undefined" && window.matchMedia
+    ? window.matchMedia("(min-width: 1024px)").matches
+    : true;
+</script>
+
+<template>
+  <Head title="World Clock" />
+
+  <AuthenticatedLayout>
+    <template #header>
+      <h2 class="font-heading text-2xl text-theme-title leading-tight">
+        World Clock
+      </h2>
+    </template>
+
+    <div class="max-w-6xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+      <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-1">
+          <Accordion
+            title="Clock settings"
+            :default-open="settingsOpen"
+            dark-background
+            compact
+            class="rounded-lg"
+          >
+            <div class="space-y-6">
+              <ClockCustomizer
+                v-model:face-preset="prefs.facePreset"
+                v-model:hand-preset="prefs.handPreset"
+                v-model:numerals="prefs.numerals"
+                v-model:second-hand-mode="prefs.secondHandMode"
+              />
+              <CityPicker
+                :selected-cities="prefs.cities"
+                :max-cities="maxCities"
+                @add="addCity"
+                @remove="removeCity"
+              />
+            </div>
+          </Accordion>
+        </div>
+
+        <div class="lg:col-span-2">
+          <WorldClockGrid
+            :cities="prefs.cities"
+            :face-preset="prefs.facePreset"
+            :hand-preset="prefs.handPreset"
+            :numerals="prefs.numerals"
+            :second-hand-mode="prefs.secondHandMode"
+          />
+        </div>
+      </div>
+    </div>
+  </AuthenticatedLayout>
+</template>

--- a/resources/js/composables/useClockTime.js
+++ b/resources/js/composables/useClockTime.js
@@ -1,0 +1,91 @@
+import { computed, onMounted, onUnmounted, ref, unref } from "vue";
+
+// Pure helper: given an IANA timezone and a Date, return the local clock parts.
+// DST is handled by the browser's Intl engine. `hours` is a 0-12 fractional
+// value (including minute/second contributions) so the hour hand sweeps
+// smoothly. Exported separately so it can be unit-tested without mounting.
+
+// Intl.DateTimeFormat is comparatively expensive to construct and this runs on
+// every animation frame for every clock, so cache one formatter per timezone.
+const formatterCache = new Map();
+function getFormatter(timeZone) {
+  let formatter = formatterCache.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit"
+    });
+    formatterCache.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+export function getZonedParts(timeZone, date) {
+  const parts = getFormatter(timeZone).formatToParts(date);
+  const read = (type) => {
+    const part = parts.find((p) => p.type === type);
+    return part ? parseInt(part.value, 10) : 0;
+  };
+
+  let hour24 = read("hour");
+  // Some engines render midnight as "24" with hour12:false.
+  if (hour24 === 24) hour24 = 0;
+  const minutes = read("minute");
+  const seconds = read("second");
+  const milliseconds = date.getMilliseconds();
+
+  return {
+    hour24,
+    minutes,
+    seconds,
+    milliseconds,
+    hours: (hour24 % 12) + minutes / 60 + seconds / 3600
+  };
+}
+
+// A single shared animation loop drives every clock on the page, so adding more
+// clocks does not add more timers. The loop only runs while at least one clock
+// is mounted.
+const now = ref(Date.now());
+let rafId = null;
+let subscribers = 0;
+
+function tick() {
+  now.value = Date.now();
+  rafId = requestAnimationFrame(tick);
+}
+
+function startTicking() {
+  subscribers += 1;
+  if (subscribers === 1 && typeof requestAnimationFrame === "function") {
+    tick();
+  }
+}
+
+function stopTicking() {
+  subscribers = Math.max(0, subscribers - 1);
+  if (subscribers === 0 && rafId !== null) {
+    cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+}
+
+export function useClockTime(timezone) {
+  onMounted(startTicking);
+  onUnmounted(stopTicking);
+
+  const parts = computed(() =>
+    getZonedParts(unref(timezone) || "UTC", new Date(now.value))
+  );
+
+  return {
+    hours: computed(() => parts.value.hours),
+    minutes: computed(() => parts.value.minutes),
+    seconds: computed(() => parts.value.seconds),
+    milliseconds: computed(() => parts.value.milliseconds),
+    hour24: computed(() => parts.value.hour24)
+  };
+}

--- a/resources/js/composables/useClockTime.test.js
+++ b/resources/js/composables/useClockTime.test.js
@@ -1,0 +1,31 @@
+import { getZonedParts } from "@/composables/useClockTime";
+import { describe, expect, it } from "vitest";
+
+describe("composables/useClockTime getZonedParts", () => {
+  // 2024-01-15T15:30:45Z — a winter date so US zones are in standard time.
+  const instant = new Date("2024-01-15T15:30:45.000Z");
+
+  it("returns correct parts for UTC", () => {
+    const parts = getZonedParts("UTC", instant);
+    expect(parts.hour24).toBe(15);
+    expect(parts.minutes).toBe(30);
+    expect(parts.seconds).toBe(45);
+    // (15 % 12) + 30/60 + 45/3600
+    expect(parts.hours).toBeCloseTo(3.5125, 4);
+  });
+
+  it("applies the timezone offset (America/New_York, EST = UTC-5)", () => {
+    const parts = getZonedParts("America/New_York", instant);
+    expect(parts.hour24).toBe(10);
+    expect(parts.minutes).toBe(30);
+    expect(parts.seconds).toBe(45);
+    expect(parts.hours).toBeCloseTo(10.5125, 4);
+  });
+
+  it("applies a positive offset (Asia/Tokyo = UTC+9)", () => {
+    const parts = getZonedParts("Asia/Tokyo", instant);
+    // 15:30 UTC + 9h = 00:30 next day
+    expect(parts.hour24).toBe(0);
+    expect(parts.minutes).toBe(30);
+  });
+});

--- a/resources/js/composables/useGlobalTimer.js
+++ b/resources/js/composables/useGlobalTimer.js
@@ -1,0 +1,76 @@
+import { computed, ref } from "vue";
+
+// A single shared countdown timer for the whole app. Every clock (including the
+// nav logo clock) reads this same state, so the red timer pie is identical
+// everywhere. Module-level singleton — controls live in one place (the World
+// Clock customizer) but the visual applies to all clocks.
+
+const HOUR_MS = 60 * 60 * 1000;
+
+const endTime = ref(0);
+const remainingMs = ref(0);
+const active = ref(false);
+let intervalId = null;
+let completed = false;
+
+const clear = () => {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+};
+
+// Speak "Time's up!" using the user's stored speech settings, independent of
+// any mounted component so it fires even when the timer finishes on another
+// page (the logo clock keeps the timer visible app-wide).
+const announce = (text) => {
+  if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+  try {
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.rate = parseFloat(localStorage.getItem("speechRate") || "1");
+    utterance.pitch = parseFloat(localStorage.getItem("speechPitch") || "1");
+    utterance.volume = parseFloat(localStorage.getItem("speechVolume") || "1");
+    const voices = window.speechSynthesis.getVoices();
+    const index = parseInt(localStorage.getItem("selectedVoiceIndex") || "0", 10);
+    if (voices && voices[index]) utterance.voice = voices[index];
+    window.speechSynthesis.speak(utterance);
+  } catch (e) {
+    console.error("Error announcing timer:", e);
+  }
+};
+
+const update = () => {
+  const rem = Math.max(0, endTime.value - Date.now());
+  remainingMs.value = rem;
+  if (rem <= 0 && active.value) {
+    active.value = false;
+    clear();
+    if (!completed) {
+      completed = true;
+      announce("Time's up!");
+    }
+  }
+};
+
+const start = (seconds) => {
+  completed = false;
+  endTime.value = Date.now() + seconds * 1000;
+  remainingMs.value = seconds * 1000;
+  active.value = true;
+  clear();
+  intervalId = setInterval(update, 250);
+};
+
+const stop = () => {
+  active.value = false;
+  completed = false;
+  remainingMs.value = 0;
+  clear();
+};
+
+const remainingSeconds = computed(() => Math.ceil(remainingMs.value / 1000));
+const fraction = computed(() => Math.min(1, remainingMs.value / HOUR_MS));
+
+export function useGlobalTimer() {
+  return { active, remainingMs, remainingSeconds, fraction, start, stop };
+}

--- a/resources/js/composables/useGlobalTimer.test.js
+++ b/resources/js/composables/useGlobalTimer.test.js
@@ -1,0 +1,51 @@
+import { useGlobalTimer } from "@/composables/useGlobalTimer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("composables/useGlobalTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+    window.speechSynthesis.speak.mockClear();
+    useGlobalTimer().stop();
+  });
+
+  afterEach(() => {
+    useGlobalTimer().stop();
+    vi.useRealTimers();
+  });
+
+  it("is a shared singleton across calls", () => {
+    const a = useGlobalTimer();
+    const b = useGlobalTimer();
+    a.start(30 * 60);
+    expect(b.active.value).toBe(true);
+    expect(b.fraction.value).toBeCloseTo(0.5, 2);
+  });
+
+  it("shrinks the fraction as time elapses", () => {
+    const t = useGlobalTimer();
+    t.start(60 * 60);
+    expect(t.fraction.value).toBeCloseTo(1, 2);
+    vi.advanceTimersByTime(30 * 60 * 1000);
+    expect(t.fraction.value).toBeCloseTo(0.5, 1);
+  });
+
+  it("announces once and goes inactive at zero", () => {
+    const t = useGlobalTimer();
+    t.start(15 * 60);
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    expect(t.active.value).toBe(false);
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(60 * 1000);
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() halts the timer without announcing", () => {
+    const t = useGlobalTimer();
+    t.start(30 * 60);
+    t.stop();
+    expect(t.active.value).toBe(false);
+    vi.advanceTimersByTime(30 * 60 * 1000);
+    expect(window.speechSynthesis.speak).not.toHaveBeenCalled();
+  });
+});

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -50,6 +50,7 @@ export function useLogoPreference() {
       handPreset: config.handPreset || "classic",
       numerals: config.numerals || "none"
     });
+    });
   }
 
   function clearLogoClock() {

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -1,0 +1,60 @@
+import { reactive, toRaw, watch } from "vue";
+
+// Lets the user replace the top-left nav logo with a configured clock. State is
+// a module-level singleton reactive object so a write from the World Clock page
+// is reflected live in the nav (localStorage alone is not cross-component
+// reactive). The choice persists in localStorage across reloads.
+
+const STORAGE_KEY = "shudderfly.worldClock.logo";
+
+const DEFAULT = {
+  enabled: false,
+  cityName: "",
+  timezone: "",
+  facePreset: "theme",
+  handPreset: "classic",
+  numerals: "none"
+};
+
+const logo = reactive({ ...DEFAULT });
+
+try {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === "object") Object.assign(logo, parsed);
+  }
+} catch (e) {
+  console.error("Error loading logo preference:", e);
+}
+
+watch(
+  logo,
+  () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(toRaw(logo)));
+    } catch (e) {
+      console.error("Error saving logo preference:", e);
+    }
+  },
+  { deep: true }
+);
+
+export function useLogoPreference() {
+  function setLogoClock(config) {
+    Object.assign(logo, {
+      enabled: true,
+      cityName: config.cityName || "",
+      timezone: config.timezone,
+      facePreset: config.facePreset || "classic",
+      handPreset: config.handPreset || "classic",
+      numerals: config.numerals || "none"
+    });
+  }
+
+  function clearLogoClock() {
+    Object.assign(logo, { ...DEFAULT });
+  }
+
+  return { logo, setLogoClock, clearLogoClock };
+}

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -50,7 +50,6 @@ export function useLogoPreference() {
       handPreset: config.handPreset || "classic",
       numerals: config.numerals || "none"
     });
-    });
   }
 
   function clearLogoClock() {

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -45,7 +45,7 @@ export function useLogoPreference() {
     Object.assign(logo, {
       enabled: true,
       cityName: config.cityName || "",
-      timezone: config.timezone,
+      timezone: config.timezone || "",
       facePreset: config.facePreset || "classic",
       handPreset: config.handPreset || "classic",
       numerals: config.numerals || "none"

--- a/resources/js/composables/useLogoPreference.test.js
+++ b/resources/js/composables/useLogoPreference.test.js
@@ -1,0 +1,53 @@
+import { useLogoPreference } from "@/composables/useLogoPreference";
+import { beforeEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+
+const STORAGE_KEY = "shudderfly.worldClock.logo";
+
+describe("composables/useLogoPreference", () => {
+  beforeEach(() => {
+    const { clearLogoClock } = useLogoPreference();
+    clearLogoClock();
+    localStorage.clear();
+  });
+
+  it("starts disabled by default", () => {
+    const { logo } = useLogoPreference();
+    expect(logo.enabled).toBe(false);
+  });
+
+  it("setLogoClock enables and stores the chosen clock", async () => {
+    const { logo, setLogoClock } = useLogoPreference();
+    setLogoClock({
+      cityName: "Tokyo",
+      timezone: "Asia/Tokyo",
+      facePreset: "night",
+      handPreset: "ornate",
+      numerals: "roman"
+    });
+
+    expect(logo.enabled).toBe(true);
+    expect(logo.timezone).toBe("Asia/Tokyo");
+    expect(logo.cityName).toBe("Tokyo");
+
+    await nextTick();
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(stored.enabled).toBe(true);
+    expect(stored.timezone).toBe("Asia/Tokyo");
+    expect(stored.facePreset).toBe("night");
+  });
+
+  it("clearLogoClock resets to the default logo", async () => {
+    const { logo, setLogoClock, clearLogoClock } = useLogoPreference();
+    setLogoClock({ cityName: "Paris", timezone: "Europe/Paris" });
+    expect(logo.enabled).toBe(true);
+
+    clearLogoClock();
+    expect(logo.enabled).toBe(false);
+    expect(logo.timezone).toBe("");
+
+    await nextTick();
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(stored.enabled).toBe(false);
+  });
+});

--- a/resources/js/composables/useWorldClockPreferences.js
+++ b/resources/js/composables/useWorldClockPreferences.js
@@ -1,0 +1,89 @@
+import { reactive, toRaw, watch } from "vue";
+
+const STORAGE_KEY = "shudderfly.worldClock";
+
+const DEFAULTS = {
+  facePreset: "theme",
+  handPreset: "classic",
+  numerals: "arabic",
+  secondHandMode: "smooth",
+  cities: []
+};
+
+function sanitize(raw) {
+  const clean = {};
+  if (typeof raw.facePreset === "string") clean.facePreset = raw.facePreset;
+  if (typeof raw.handPreset === "string") clean.handPreset = raw.handPreset;
+  if (typeof raw.numerals === "string") clean.numerals = raw.numerals;
+  if (typeof raw.secondHandMode === "string")
+    clean.secondHandMode = raw.secondHandMode;
+  if (Array.isArray(raw.cities)) {
+    clean.cities = raw.cities
+      .filter((c) => c && c.timezone && c.name)
+      .map((c) => ({
+        name: String(c.name),
+        timezone: String(c.timezone),
+        country: c.country ? String(c.country) : ""
+      }));
+  }
+  return clean;
+}
+
+export function useWorldClockPreferences(defaultCities = [], maxCities = 6) {
+  const prefs = reactive({ ...DEFAULTS });
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) Object.assign(prefs, sanitize(JSON.parse(stored)));
+  } catch (e) {
+    console.error("Error loading world clock preferences:", e);
+  }
+
+  if (!prefs.cities.length) {
+    prefs.cities = defaultCities.slice(0, maxCities).map((c) => ({
+      name: c.name,
+      timezone: c.timezone,
+      country: c.country || ""
+    }));
+  }
+
+  let timer = null;
+  watch(
+    prefs,
+    () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(toRaw(prefs)));
+        } catch (e) {
+          console.error("Error saving world clock preferences:", e);
+        }
+      }, 300);
+    },
+    { deep: true }
+  );
+
+  const hasCity = (city) =>
+    prefs.cities.some(
+      (c) => c.timezone === city.timezone && c.name === city.name
+    );
+
+  function addCity(city) {
+    if (prefs.cities.length >= maxCities) return false;
+    if (hasCity(city)) return false;
+    prefs.cities.push({
+      name: city.name,
+      timezone: city.timezone,
+      country: city.country || ""
+    });
+    return true;
+  }
+
+  function removeCity(city) {
+    prefs.cities = prefs.cities.filter(
+      (c) => !(c.timezone === city.timezone && c.name === city.name)
+    );
+  }
+
+  return { prefs, addCity, removeCity, hasCity, maxCities };
+}

--- a/resources/js/composables/useWorldClockPreferences.js
+++ b/resources/js/composables/useWorldClockPreferences.js
@@ -39,6 +39,8 @@ export function useWorldClockPreferences(defaultCities = [], maxCities = 6) {
     console.error("Error loading world clock preferences:", e);
   }
 
+  prefs.cities = prefs.cities.slice(0, maxCities);
+
   if (!prefs.cities.length) {
     prefs.cities = defaultCities.slice(0, maxCities).map((c) => ({
       name: c.name,

--- a/resources/js/vitest.setup.js
+++ b/resources/js/vitest.setup.js
@@ -111,6 +111,8 @@ export const ROUTE_MAPPINGS = {
     "movie-cast.favorites.store": "/movie-cast/favorites",
     "movie-cast.favorites.destroy": (params) => `/movie-cast/favorites/${params}`,
     "movie-cast.share": "/movie-cast/share",
+    "world-clock.index": "/world-clock",
+    "world-clock.cities.search": "/api/world-clock/cities/search",
 };
 
 export const createRouteMock = () =>

--- a/resources/js/world-clock/presets/faces.js
+++ b/resources/js/world-clock/presets/faces.js
@@ -1,0 +1,100 @@
+// Clock face presets. Each preset describes the palette of the clock:
+// the face fill (solid color or radial gradient stops), rim, tick marks,
+// numeral styling, and hand/second/cap colors. The hand *silhouette* comes
+// from the hand presets; faces only provide colors so the two compose freely.
+// A custom face image (if provided) overrides `faceFill` but keeps everything
+// drawn on top (ticks, numerals, hands).
+
+export const FACE_PRESETS = {
+  theme: {
+    id: "theme",
+    label: "Theme",
+    numerals: "arabic",
+    // CSS variables defined in app.css; they track the active site theme and
+    // dark mode, so this face matches the rest of the app.
+    faceFill: "var(--wc-face)",
+    rimColor: "var(--wc-rim)",
+    rimWidth: 3,
+    tickColor: "var(--wc-tick)",
+    tickMinorColor: "var(--wc-tick-minor)",
+    showMinorTicks: true,
+    numeralColor: "var(--wc-numeral)",
+    numeralFont: "Nunito, system-ui, sans-serif",
+    handColor: "var(--wc-hand)",
+    secondColor: "var(--wc-second)",
+    capColor: "var(--wc-cap)"
+  },
+  classic: {
+    id: "classic",
+    label: "Classic",
+    numerals: "arabic",
+    faceFill: "#fdfcf7",
+    rimColor: "#1f2937",
+    rimWidth: 3,
+    tickColor: "#1f2937",
+    tickMinorColor: "#9ca3af",
+    showMinorTicks: true,
+    numeralColor: "#1f2937",
+    numeralFont: "Georgia, 'Times New Roman', serif",
+    handColor: "#111827",
+    secondColor: "#dc2626",
+    capColor: "#111827"
+  },
+  "roman-gold": {
+    id: "roman-gold",
+    label: "Roman Gold",
+    numerals: "roman",
+    gradient: ["#3b3326", "#1c1813"],
+    rimColor: "#c9a227",
+    rimWidth: 4,
+    tickColor: "#c9a227",
+    tickMinorColor: "#7c6a2e",
+    showMinorTicks: false,
+    numeralColor: "#e8c766",
+    numeralFont: "Georgia, 'Times New Roman', serif",
+    handColor: "#e8c766",
+    secondColor: "#c9a227",
+    capColor: "#c9a227"
+  },
+  minimal: {
+    id: "minimal",
+    label: "Minimal",
+    numerals: "none",
+    faceFill: "#e5e7eb",
+    rimColor: "#9ca3af",
+    rimWidth: 1,
+    tickColor: "#6b7280",
+    tickMinorColor: "#cbd5e1",
+    showMinorTicks: false,
+    numeralColor: "#6b7280",
+    numeralFont: "system-ui, sans-serif",
+    handColor: "#374151",
+    secondColor: "#374151",
+    capColor: "#374151"
+  },
+  night: {
+    id: "night",
+    label: "Night",
+    numerals: "arabic",
+    gradient: ["#1e293b", "#0f172a"],
+    rimColor: "#475569",
+    rimWidth: 2,
+    tickColor: "#cbd5e1",
+    tickMinorColor: "#64748b",
+    showMinorTicks: true,
+    numeralColor: "#e2e8f0",
+    numeralFont: "system-ui, sans-serif",
+    handColor: "#f1f5f9",
+    secondColor: "#38bdf8",
+    capColor: "#f1f5f9"
+  }
+};
+
+export const FACE_OPTIONS = Object.values(FACE_PRESETS).map((f) => ({
+  value: f.id,
+  label: f.label
+}));
+
+export function getFacePreset(id) {
+  return FACE_PRESETS[id] || FACE_PRESETS.classic;
+}

--- a/resources/js/world-clock/presets/faces.js
+++ b/resources/js/world-clock/presets/faces.js
@@ -2,8 +2,6 @@
 // the face fill (solid color or radial gradient stops), rim, tick marks,
 // numeral styling, and hand/second/cap colors. The hand *silhouette* comes
 // from the hand presets; faces only provide colors so the two compose freely.
-// A custom face image (if provided) overrides `faceFill` but keeps everything
-// drawn on top (ticks, numerals, hands).
 
 export const FACE_PRESETS = {
   theme: {

--- a/resources/js/world-clock/presets/hands.js
+++ b/resources/js/world-clock/presets/hands.js
@@ -1,0 +1,40 @@
+// Clock hand presets. Each hand is a closed SVG path expressed in a coordinate
+// space whose origin (0,0) is the clock center; negative Y points up, so every
+// path is drawn pointing to 12 o'clock and then rotated into place by the
+// AnalogClock component. Colors are supplied by the face preset, not here, so
+// silhouettes and palettes compose independently.
+
+export const HAND_PRESETS = {
+  classic: {
+    id: "classic",
+    label: "Classic",
+    hour: "M -2.4 6 L -2.4 -27 Q 0 -31 2.4 -27 L 2.4 6 Z",
+    minute: "M -1.8 8 L -1.8 -40 Q 0 -43 1.8 -40 L 1.8 8 Z",
+    second: "M -0.7 12 L -0.7 -45 L 0.7 -45 L 0.7 12 Z"
+  },
+  ornate: {
+    id: "ornate",
+    label: "Ornate",
+    hour: "M 0 9 L -3.4 -6 L -1.8 -20 L 0 -29 L 1.8 -20 L 3.4 -6 Z",
+    minute: "M 0 11 L -2.6 -8 L -1.2 -30 L 0 -42 L 1.2 -30 L 2.6 -8 Z",
+    second:
+      "M -0.6 -46 L 0.6 -46 L 0.6 10 L -0.6 10 Z M 0 13 m -3 0 a 3 3 0 1 0 6 0 a 3 3 0 1 0 -6 0"
+  },
+  skeleton: {
+    id: "skeleton",
+    label: "Skeleton",
+    hour: "M -1 5 L -1 -26 L 1 -26 L 1 5 Z",
+    minute: "M -0.8 5 L -0.8 -40 L 0.8 -40 L 0.8 5 Z",
+    second:
+      "M -0.4 -46 L 0.4 -46 L 0.4 16 L -0.4 16 Z M 0 16 m -2.5 0 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0"
+  }
+};
+
+export const HAND_OPTIONS = Object.values(HAND_PRESETS).map((h) => ({
+  value: h.id,
+  label: h.label
+}));
+
+export function getHandPreset(id) {
+  return HAND_PRESETS[id] || HAND_PRESETS.classic;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\SoundsController;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\WorldClockController;
 use App\Http\Controllers\YouTubeProxyController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -83,6 +84,10 @@ Route::middleware('auth')->group(function () {
     Route::post('/movie-cast/favorites', [MovieCastController::class, 'storeFavorite'])->name('movie-cast.favorites.store');
     Route::delete('/movie-cast/favorites/{tmdbId}', [MovieCastController::class, 'destroyFavorite'])->name('movie-cast.favorites.destroy');
     Route::post('/movie-cast/share', [MovieCastController::class, 'share'])->name('movie-cast.share');
+
+    Route::get('/world-clock', [WorldClockController::class, 'index'])->name('world-clock.index');
+    Route::get('/api/world-clock/cities/search', [WorldClockController::class, 'searchCities'])
+        ->name('world-clock.cities.search');
 
     Route::post('/collage-page', [CollagePageController::class, 'store'])->name('collage-page.store');
 

--- a/tests/Feature/WorldClockTest.php
+++ b/tests/Feature/WorldClockTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class WorldClockTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_access_world_clock(): void
+    {
+        $this->get(route('world-clock.index'))->assertRedirect(route('login'));
+        $this->getJson(route('world-clock.cities.search', ['q' => 'tokyo']))
+            ->assertUnauthorized();
+    }
+
+    public function test_world_clock_page_renders(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->get(route('world-clock.index'))->assertInertia(
+            fn (Assert $page) => $page
+                ->component('WorldClock/Index')
+                ->where('maxCities', 6)
+                ->has('defaultCities')
+                ->where('defaultCities.0.timezone', 'America/New_York')
+        );
+    }
+
+    public function test_city_search_requires_query(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->getJson(route('world-clock.cities.search'))->assertStatus(422);
+        $this->getJson(route('world-clock.cities.search', ['q' => 'a']))->assertStatus(422);
+    }
+
+    public function test_city_search_returns_matches(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $response = $this->getJson(route('world-clock.cities.search', ['q' => 'tok']));
+
+        $response->assertOk();
+
+        $results = $response->json();
+        $this->assertNotEmpty($results);
+        $this->assertContains('Asia/Tokyo', array_column($results, 'timezone'));
+
+        foreach ($results as $city) {
+            $this->assertArrayHasKey('name', $city);
+            $this->assertArrayHasKey('timezone', $city);
+            $this->assertArrayHasKey('country', $city);
+        }
+    }
+
+    public function test_city_search_matches_by_country(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $response = $this->getJson(route('world-clock.cities.search', ['q' => 'japan']));
+
+        $response->assertOk();
+        $this->assertContains('Tokyo', array_column($response->json(), 'name'));
+    }
+
+    public function test_city_search_no_match_returns_empty(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->getJson(route('world-clock.cities.search', ['q' => 'zzzznowhere']))
+            ->assertOk()
+            ->assertExactJson([]);
+    }
+}


### PR DESCRIPTION
## Overview
Adds an authenticated `/world-clock` page showing live analog clocks for multiple cities' local times (native `Intl`, DST-correct — no per-second external calls). Follows existing Inertia/Vue conventions (mirrors MovieCast/Games).

## Features
- **Clock faces & hands:** 4 face presets (including a **Theme** face that follows the active site theme + dark mode via `--wc-*` CSS variables), 3 hand presets, and Arabic/Roman/no numerals.
- **Cities:** search proxied through `WorldClockController` against a bundled ~115-city list (offline, no third-party API). 1–6 cities; selections + styles persist in `localStorage`.
- **Shared countdown timer:** 15/30/45/60-min, drawn as a shrinking **deep-red pie** on every clock — including the nav logo clock — controlled from one place; announces "Time's up!" on completion, with a speak button for remaining time.
- **Speech:** each clock has a speak button announcing city + 12-hour time; settings speak their choice when tapped (kid-friendly).
- **Clock-as-logo:** pin any clock as the live, ticking nav app logo (still links home); persists in `localStorage`.
- **Mobile:** settings collapse into an accordion so the clocks lead.

## Backend
- `WorldClockController@index` renders the page with `defaultCities` + `maxCities`.
- `WorldClockController@searchCities` validates `q` and filters a static `config/world_clock.php` list. Both routes are inside the `auth` group.

## Tests
- **PHPUnit** (`WorldClockTest`): auth required, page render, search validation (422), match by name/country, empty result.
- **Vitest**: `useClockTime` (DST math), `useGlobalTimer` (countdown/announce/stop), `useLogoPreference`, `AnalogClock` (numerals, hands, timer wedge, unique gradient id), `ClockCard` (12-hour print + spoken time).
- Full suite green: 382 JS tests; `WorldClockTest` passes. `sail pint` clean.

## Notes
- No new npm dependencies (uses native `Intl`, not luxon). No DB models or feature flag — lightweight like Games/Movies.
- Custom face-image upload was intentionally removed; nav logo clock ticks; timer is a single global instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)