### PR TITLE
Make World Clock state global and shared across all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Private family media management built with Laravel, Vue, and AWS-backed services
 
 ## Overview
 
-Shudderfly is a private media app for sharing family-friendly content without ads, public feeds, or third-party social distractions. It supports books, pages, songs, movie cast lookup, collages, messages, searchable media, and AI-generated user summaries.
+Shudderfly is a private media app for sharing family-friendly content without ads, public feeds, or third-party social distractions. It supports books, pages, songs, movie cast lookup, collages, messages, a shared world clock, searchable media, and AI-generated user summaries.
 
 ## Core Features
 
@@ -16,6 +16,7 @@ Shudderfly is a private media app for sharing family-friendly content without ad
 - Movie cast lookup (TMDB search, trailers, favorites, share to chat)
 - Song library with YouTube-based playback
 - PDF collage generation
+- Shared world clock with a synchronized timer (cities, appearance, and timer are global and update live for everyone)
 - Internal messaging and notifications
 - Role/permission-based access control
 - Fast full-text search with Meilisearch

--- a/app/Events/CollagePageRemoved.php
+++ b/app/Events/CollagePageRemoved.php
@@ -26,7 +26,7 @@ class CollagePageRemoved implements ShouldBroadcastNow
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array<int, \Illuminate\Broadcasting\PrivateChannel>
+     * @return array<int, PrivateChannel>
      */
     public function broadcastOn(): array
     {

--- a/app/Events/CommentCreated.php
+++ b/app/Events/CommentCreated.php
@@ -26,7 +26,7 @@ class CommentCreated implements ShouldBroadcastNow
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array<int, \Illuminate\Broadcasting\PrivateChannel>
+     * @return array<int, PrivateChannel>
      */
     public function broadcastOn(): array
     {

--- a/app/Events/CommentReactionUpdated.php
+++ b/app/Events/CommentReactionUpdated.php
@@ -26,7 +26,7 @@ class CommentReactionUpdated implements ShouldBroadcastNow
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array<int, \Illuminate\Broadcasting\PrivateChannel>
+     * @return array<int, PrivateChannel>
      */
     public function broadcastOn(): array
     {

--- a/app/Events/WorldClockUpdated.php
+++ b/app/Events/WorldClockUpdated.php
@@ -2,57 +2,45 @@
 
 namespace App\Events;
 
-use App\Models\Message;
+use App\Models\WorldClockSetting;
+use App\Support\WorldClockState;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class MessageReactionUpdated implements ShouldBroadcastNow
+class WorldClockUpdated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public Message $message;
+    public WorldClockSetting $setting;
 
-    /**
-     * Create a new event instance.
-     */
-    public function __construct(Message $message)
+    public function __construct(WorldClockSetting $setting)
     {
-        $this->message = $message;
+        $this->setting = $setting;
     }
 
     /**
-     * Get the channels the event should broadcast on.
-     *
      * @return array<int, PrivateChannel>
      */
     public function broadcastOn(): array
     {
         return [
-            new PrivateChannel('messages'),
+            new PrivateChannel('world-clock'),
         ];
     }
 
-    /**
-     * The event's broadcast name.
-     */
     public function broadcastAs(): string
     {
-        return 'MessageReactionUpdated';
+        return 'WorldClockUpdated';
     }
 
     /**
-     * Get the data to broadcast.
-     *
      * @return array<string, mixed>
      */
     public function broadcastWith(): array
     {
-        return [
-            'message_id' => $this->message->id,
-            'grouped_reactions' => $this->message->getGroupedReactions(),
-        ];
+        return WorldClockState::payload($this->setting);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
@@ -15,7 +16,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of exception types with their corresponding custom log levels.
      *
-     * @var array<class-string<Throwable>, \Psr\Log\LogLevel::*>
+     * @var array<class-string<Throwable>, LogLevel::*>
      */
     protected $levels = [
         //

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -5,17 +5,19 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class AuthenticatedSessionController extends Controller
 {
     /**
      * Display the login view.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function create()
     {
@@ -28,7 +30,7 @@ class AuthenticatedSessionController extends Controller
     /**
      * Handle an incoming authentication request.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function store(LoginRequest $request)
     {
@@ -42,7 +44,7 @@ class AuthenticatedSessionController extends Controller
     /**
      * Destroy an authenticated session.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function destroy(Request $request)
     {

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -8,13 +8,14 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class ConfirmablePasswordController extends Controller
 {
     /**
      * Show the confirm password view.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function show()
     {

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class EmailVerificationNotificationController extends Controller
@@ -11,7 +12,7 @@ class EmailVerificationNotificationController extends Controller
     /**
      * Send a new email verification notification.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function store(Request $request)
     {

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
@@ -11,13 +12,14 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class NewPasswordController extends Controller
 {
     /**
      * Display the password reset view.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function create(Request $request)
     {
@@ -30,9 +32,9 @@ class NewPasswordController extends Controller
     /**
      * Handle an incoming new password request.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request)
     {

--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
@@ -12,7 +13,7 @@ class PasswordController extends Controller
     /**
      * Update the user's password.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function update(Request $request)
     {

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -3,17 +3,19 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class PasswordResetLinkController extends Controller
 {
     /**
      * Display the password reset link request view.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function create()
     {
@@ -25,9 +27,9 @@ class PasswordResetLinkController extends Controller
     /**
      * Handle an incoming password reset link request.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request)
     {

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -6,18 +6,21 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class RegisteredUserController extends Controller
 {
     /**
      * Display the registration view.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function create()
     {
@@ -27,9 +30,9 @@ class RegisteredUserController extends Controller
     /**
      * Handle an incoming registration request.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request)
     {

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -6,13 +6,14 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\RedirectResponse;
 
 class VerifyEmailController extends Controller
 {
     /**
      * Mark the authenticated user's email address as verified.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function __invoke(EmailVerificationRequest $request)
     {

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -13,6 +13,7 @@ use App\Models\Song;
 use App\Models\User;
 use App\Services\PopularityService;
 use App\Services\VoiceSearchService;
+use App\Support\ReadThrottle;
 use App\Support\ThemeBooks;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection;
@@ -139,20 +140,20 @@ class BookController extends Controller
 
         if ($canIncrement) {
             // Per-actor throttle: only count one view per user/session/IP per 5 minutes (cache only)
-            $cacheKey = \App\Support\ReadThrottle::cacheKey('book', $book->id, $request);
+            $cacheKey = ReadThrottle::cacheKey('book', $book->id, $request);
             $throttleSeconds = 5 * 60;
-            $fingerprint = \App\Support\ReadThrottle::fingerprint($request);
+            $fingerprint = ReadThrottle::fingerprint($request);
             try {
                 if (Cache::add($cacheKey, 1, now()->addSeconds($throttleSeconds))) {
                     // Added successfully => no recent view by this actor
-                    \App\Support\ReadThrottle::dispatchJob(new IncrementBookReadCount($book, $fingerprint));
+                    ReadThrottle::dispatchJob(new IncrementBookReadCount($book, $fingerprint));
                 }
             } catch (\Throwable $e) {
                 // If cache is unavailable/misconfigured, skip increment to avoid inflation
             }
         }
 
-        $youtubeEnabled = \App\Models\SiteSetting::where('key', 'youtube_enabled')->first()->value;
+        $youtubeEnabled = SiteSetting::where('key', 'youtube_enabled')->first()->value;
         $sort = $request->query('sort', 'newest');
 
         $pages = $book->pages()

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Requests\StoreCategoryRequest;
 use App\Http\Requests\UpdateCategoryRequest;
 use App\Models\Book;
@@ -32,7 +33,7 @@ class CategoryController extends Controller
                 ->orderBy('read_count', 'asc')
                 ->paginate(),
             'themed' => ThemeBooks::getBooksForThemePaginated(
-                \App\Http\Middleware\HandleInertiaRequests::getCurrentTheme() ?? ''
+                HandleInertiaRequests::getCurrentTheme() ?? ''
             ),
             default => Category::where('name', $categoryName)
                 ->firstOrFail()
@@ -43,7 +44,7 @@ class CategoryController extends Controller
 
         // Get all pages with locations for ALL books in this category (not just current page)
         if ($categoryName === 'themed') {
-            $theme = \App\Http\Middleware\HandleInertiaRequests::getCurrentTheme() ?? '';
+            $theme = HandleInertiaRequests::getCurrentTheme() ?? '';
             $keywords = ThemeBooks::getKeywords($theme);
             $allBookIds = empty($keywords) ? collect([]) : Book::query()
                 ->where(function ($q) use ($keywords) {

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -7,12 +7,15 @@ use App\Mail\ContactAdmins;
 use App\Models\User;
 use App\Services\PushNotificationService;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class ProfileController extends Controller
 {
@@ -23,7 +26,7 @@ class ProfileController extends Controller
     /**
      * Display the user's profile form.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function edit(Request $request)
     {
@@ -39,7 +42,7 @@ class ProfileController extends Controller
     /**
      * Update the user's profile information.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function update(ProfileUpdateRequest $request)
     {
@@ -57,7 +60,7 @@ class ProfileController extends Controller
     /**
      * Update the user's notification preferences.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function updateNotificationPreferences(Request $request)
     {
@@ -74,7 +77,7 @@ class ProfileController extends Controller
     /**
      * Update the user's avatar.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function updateAvatar(Request $request)
     {
@@ -115,7 +118,7 @@ class ProfileController extends Controller
     /**
      * Delete the user's account.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function destroy(Request $request)
     {
@@ -174,7 +177,7 @@ class ProfileController extends Controller
     /**
      * Get the user's notifications.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function notifications(Request $request)
     {
@@ -189,7 +192,7 @@ class ProfileController extends Controller
     /**
      * Mark a notification as read.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function markNotificationAsRead(Request $request, string $id)
     {
@@ -208,7 +211,7 @@ class ProfileController extends Controller
     /**
      * Mark all notifications as read.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function markAllNotificationsAsRead(Request $request)
     {
@@ -220,7 +223,7 @@ class ProfileController extends Controller
     /**
      * Delete a notification.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function deleteNotification(Request $request, string $id)
     {

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -6,6 +6,7 @@ use App\Models\Book;
 use App\Models\Page;
 use App\Models\Song;
 use App\Services\VoiceSearchService;
+use GuzzleHttp\Client;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -206,7 +207,7 @@ class SearchController extends Controller
 
         try {
             // Use Guzzle's query parameter handling to properly encode values
-            $client = new \GuzzleHttp\Client;
+            $client = new Client;
             $response = $client->get('https://nominatim.openstreetmap.org/reverse', [
                 'query' => [
                     'format' => 'json',

--- a/app/Http/Controllers/WorldClockController.php
+++ b/app/Http/Controllers/WorldClockController.php
@@ -75,9 +75,6 @@ class WorldClockController extends Controller
             'enabled' => ['required', 'boolean'],
             'cityName' => ['nullable', 'string', 'max:100'],
             'timezone' => ['nullable', 'string', 'max:100'],
-            'facePreset' => ['nullable', 'string', 'max:50'],
-            'handPreset' => ['nullable', 'string', 'max:50'],
-            'numerals' => ['nullable', 'string', 'max:50'],
         ]);
 
         $setting = WorldClockSetting::instance();
@@ -85,9 +82,6 @@ class WorldClockController extends Controller
             'enabled' => $validated['enabled'],
             'cityName' => $validated['cityName'] ?? '',
             'timezone' => $validated['timezone'] ?? '',
-            'facePreset' => $validated['facePreset'] ?? 'theme',
-            'handPreset' => $validated['handPreset'] ?? 'classic',
-            'numerals' => $validated['numerals'] ?? 'none',
         ]]);
 
         return $this->broadcastAndRespond($setting);

--- a/app/Http/Controllers/WorldClockController.php
+++ b/app/Http/Controllers/WorldClockController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Events\WorldClockUpdated;
+use App\Models\WorldClockSetting;
+use App\Support\WorldClockState;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -14,6 +17,7 @@ class WorldClockController extends Controller
         return Inertia::render('WorldClock/Index', [
             'defaultCities' => config('world_clock.default_cities'),
             'maxCities' => config('world_clock.max_cities'),
+            'worldClock' => WorldClockState::payload(WorldClockSetting::instance()),
         ]);
     }
 
@@ -34,5 +38,90 @@ class WorldClockController extends Controller
             ->all();
 
         return response()->json($results);
+    }
+
+    public function updateSettings(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'cities' => ['present', 'array', 'max:'.config('world_clock.max_cities')],
+            'cities.*.name' => ['required', 'string', 'max:100'],
+            'cities.*.timezone' => ['required', 'string', 'max:100'],
+            'cities.*.country' => ['nullable', 'string', 'max:100'],
+            'face_preset' => ['required', 'string', 'max:50'],
+            'hand_preset' => ['required', 'string', 'max:50'],
+            'numerals' => ['required', 'string', 'max:50'],
+            'second_hand_mode' => ['required', 'string', 'max:50'],
+        ]);
+
+        $setting = WorldClockSetting::instance();
+        $setting->update([
+            'cities' => collect($validated['cities'])->map(fn ($c) => [
+                'name' => $c['name'],
+                'timezone' => $c['timezone'],
+                'country' => $c['country'] ?? '',
+            ])->values()->all(),
+            'face_preset' => $validated['face_preset'],
+            'hand_preset' => $validated['hand_preset'],
+            'numerals' => $validated['numerals'],
+            'second_hand_mode' => $validated['second_hand_mode'],
+        ]);
+
+        return $this->broadcastAndRespond($setting);
+    }
+
+    public function updateLogo(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+            'cityName' => ['nullable', 'string', 'max:100'],
+            'timezone' => ['nullable', 'string', 'max:100'],
+            'facePreset' => ['nullable', 'string', 'max:50'],
+            'handPreset' => ['nullable', 'string', 'max:50'],
+            'numerals' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $setting = WorldClockSetting::instance();
+        $setting->update(['logo' => [
+            'enabled' => $validated['enabled'],
+            'cityName' => $validated['cityName'] ?? '',
+            'timezone' => $validated['timezone'] ?? '',
+            'facePreset' => $validated['facePreset'] ?? 'theme',
+            'handPreset' => $validated['handPreset'] ?? 'classic',
+            'numerals' => $validated['numerals'] ?? 'none',
+        ]]);
+
+        return $this->broadcastAndRespond($setting);
+    }
+
+    public function startTimer(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'seconds' => ['required', 'integer', 'min:1', 'max:'.(24 * 60 * 60)],
+        ]);
+
+        $setting = WorldClockSetting::instance();
+        $setting->update(['timer_ends_at' => now()->addSeconds($validated['seconds'])]);
+
+        return $this->broadcastAndRespond($setting);
+    }
+
+    public function stopTimer(): JsonResponse
+    {
+        $setting = WorldClockSetting::instance();
+        $setting->update(['timer_ends_at' => null]);
+
+        return $this->broadcastAndRespond($setting);
+    }
+
+    /**
+     * Broadcast the change to every other connected client (the originator is
+     * excluded via the X-Socket-ID header) and return the fresh state so the
+     * caller can reconcile even when websockets are unavailable.
+     */
+    private function broadcastAndRespond(WorldClockSetting $setting): JsonResponse
+    {
+        broadcast(new WorldClockUpdated($setting))->toOthers();
+
+        return response()->json(WorldClockState::payload($setting));
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,7 +2,32 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\PreventRequestsDuringMaintenance;
+use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\TrimStrings;
+use App\Http\Middleware\TrustProxies;
+use App\Http\Middleware\ValidateSignature;
+use App\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
+use Illuminate\Auth\Middleware\Authorize;
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
+use Illuminate\Auth\Middleware\RequirePassword;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
+use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Middleware\SetCacheHeaders;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 class Kernel extends HttpKernel
 {
@@ -15,12 +40,12 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
-        \App\Http\Middleware\TrustProxies::class,
-        \Illuminate\Http\Middleware\HandleCors::class,
-        \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
-        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \App\Http\Middleware\TrimStrings::class,
-        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        TrustProxies::class,
+        HandleCors::class,
+        PreventRequestsDuringMaintenance::class,
+        ValidatePostSize::class,
+        TrimStrings::class,
+        ConvertEmptyStringsToNull::class,
     ];
 
     /**
@@ -30,20 +55,20 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\VerifyCsrfToken::class,
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\HandleInertiaRequests::class,
-            \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
+            EncryptCookies::class,
+            AddQueuedCookiesToResponse::class,
+            StartSession::class,
+            ShareErrorsFromSession::class,
+            VerifyCsrfToken::class,
+            SubstituteBindings::class,
+            HandleInertiaRequests::class,
+            AddLinkHeadersForPreloadedAssets::class,
         ],
 
         'api' => [
-            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            SubstituteBindings::class,
         ],
     ];
 
@@ -55,15 +80,15 @@ class Kernel extends HttpKernel
      * @var array<string, class-string|string>
      */
     protected $routeMiddleware = [
-        'auth' => \App\Http\Middleware\Authenticate::class,
-        'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,
-        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
-        'can' => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
-        'signed' => \App\Http\Middleware\ValidateSignature::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'auth' => Authenticate::class,
+        'auth.basic' => AuthenticateWithBasicAuth::class,
+        'auth.session' => AuthenticateSession::class,
+        'cache.headers' => SetCacheHeaders::class,
+        'can' => Authorize::class,
+        'guest' => RedirectIfAuthenticated::class,
+        'password.confirm' => RequirePassword::class,
+        'signed' => ValidateSignature::class,
+        'throttle' => ThrottleRequests::class,
+        'verified' => EnsureEmailIsVerified::class,
     ];
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -3,13 +3,14 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Http\Request;
 
 class Authenticate extends Middleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return string|null
      */
     protected function redirectTo($request)

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,8 @@ namespace App\Http\Middleware;
 
 use App\Models\SiteSetting;
 use App\Models\User;
+use App\Models\WorldClockSetting;
+use App\Support\WorldClockState;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Tightenco\Ziggy\Ziggy;
@@ -91,6 +93,9 @@ class HandleInertiaRequests extends Middleware
             }),
             'theme' => self::getCurrentTheme(),
             'collageMaxPages' => (int) config('collage.max_pages'),
+            'worldClock' => fn () => $request->user()
+                ? WorldClockState::payload(WorldClockSetting::instance())
+                : null,
             'flash' => [
                 'success' => fn () => $request->session()->get('success'),
                 'error' => fn () => $request->session()->get('error'),

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -4,7 +4,9 @@ namespace App\Http\Middleware;
 
 use App\Providers\RouteServiceProvider;
 use Closure;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 class RedirectIfAuthenticated
@@ -12,9 +14,9 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @param  Closure(Request): (Response|RedirectResponse)  $next
      * @param  string|null  ...$guards
-     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     * @return Response|RedirectResponse
      */
     public function handle(Request $request, Closure $next, ...$guards)
     {

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -39,7 +39,7 @@ class LoginRequest extends FormRequest
      *
      * @return void
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function authenticate()
     {
@@ -61,7 +61,7 @@ class LoginRequest extends FormRequest
      *
      * @return void
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function ensureIsNotRateLimited()
     {

--- a/app/Mail/CollagePdfMail.php
+++ b/app/Mail/CollagePdfMail.php
@@ -5,6 +5,7 @@ namespace App\Mail;
 use App\Models\Collage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -51,7 +52,7 @@ class CollagePdfMail extends Mailable
     /**
      * Get the attachments for the message.
      *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     * @return array<int, Attachment>
      */
     public function attachments(): array
     {

--- a/app/Mail/ContactAdmins.php
+++ b/app/Mail/ContactAdmins.php
@@ -5,6 +5,7 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -53,7 +54,7 @@ class ContactAdmins extends Mailable
     /**
      * Get the attachments for the message.
      *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     * @return array<int, Attachment>
      */
     public function attachments(): array
     {

--- a/app/Models/WorldClockSetting.php
+++ b/app/Models/WorldClockSetting.php
@@ -32,7 +32,11 @@ class WorldClockSetting extends Model
         $setting = static::firstOrCreate([]);
 
         if (empty($setting->cities)) {
-            $setting->cities = config('world_clock.default_cities', []);
+            $setting->cities = array_slice(
+                config('world_clock.default_cities', []),
+                0,
+                config('world_clock.max_cities', 6)
+            );
             $setting->save();
         }
 

--- a/app/Models/WorldClockSetting.php
+++ b/app/Models/WorldClockSetting.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class WorldClockSetting extends Model
 {
     protected $fillable = [
+        'key',
         'cities',
         'face_preset',
         'hand_preset',
@@ -29,7 +30,7 @@ class WorldClockSetting extends Model
      */
     public static function instance(): self
     {
-        $setting = static::firstOrCreate([]);
+        $setting = static::firstOrCreate(['key' => 'global']);
         $max = config('world_clock.max_cities', 6);
         $cities = $setting->cities ?? [];
 

--- a/app/Models/WorldClockSetting.php
+++ b/app/Models/WorldClockSetting.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WorldClockSetting extends Model
+{
+    protected $fillable = [
+        'cities',
+        'face_preset',
+        'hand_preset',
+        'numerals',
+        'second_hand_mode',
+        'logo',
+        'timer_ends_at',
+    ];
+
+    protected $casts = [
+        'cities' => 'array',
+        'logo' => 'array',
+        'timer_ends_at' => 'datetime',
+    ];
+
+    /**
+     * The single global row of world clock settings. Always returns exactly one
+     * record, seeding the city list from config on first creation so the page
+     * works before anyone has customized it.
+     */
+    public static function instance(): self
+    {
+        $setting = static::firstOrCreate([]);
+
+        if (empty($setting->cities)) {
+            $setting->cities = config('world_clock.default_cities', []);
+            $setting->save();
+        }
+
+        return $setting;
+    }
+}

--- a/app/Models/WorldClockSetting.php
+++ b/app/Models/WorldClockSetting.php
@@ -30,13 +30,18 @@ class WorldClockSetting extends Model
     public static function instance(): self
     {
         $setting = static::firstOrCreate([]);
+        $max = config('world_clock.max_cities', 6);
+        $cities = $setting->cities ?? [];
 
-        if (empty($setting->cities)) {
-            $setting->cities = array_slice(
-                config('world_clock.default_cities', []),
-                0,
-                config('world_clock.max_cities', 6)
-            );
+        if (empty($cities)) {
+            // Seed from config on first use.
+            $setting->cities = array_slice(config('world_clock.default_cities', []), 0, $max);
+            $setting->save();
+        } elseif (count($cities) > $max) {
+            // Heal rows that exceed the limit (e.g. seeded before the cap), so
+            // saving settings — which sends the whole city list — doesn't fail
+            // validation and silently drop appearance changes.
+            $setting->cities = array_slice($cities, 0, $max);
             $setting->save();
         }
 

--- a/app/Services/PushNotificationService.php
+++ b/app/Services/PushNotificationService.php
@@ -4,6 +4,8 @@ namespace App\Services;
 
 use App\Models\PushSubscription;
 use Illuminate\Support\Facades\Log;
+use Minishlink\WebPush\Subscription;
+use Minishlink\WebPush\WebPush;
 
 class PushNotificationService
 {
@@ -75,7 +77,7 @@ class PushNotificationService
             ],
         ];
 
-        /** @var \Minishlink\WebPush\WebPush $webPush */
+        /** @var WebPush $webPush */
         $webPush = new $webPushClass($auth);
 
         // Track endpoint to subscription mapping for cleanup
@@ -96,7 +98,7 @@ class PushNotificationService
                     continue;
                 }
 
-                /** @var \Minishlink\WebPush\Subscription $pushSubscription */
+                /** @var Subscription $pushSubscription */
                 $pushSubscription = $subscriptionClass::create([
                     'endpoint' => $subscription->endpoint,
                     'keys' => $subscription->keys,

--- a/app/Support/WorldClockState.php
+++ b/app/Support/WorldClockState.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\WorldClockSetting;
+
+final class WorldClockState
+{
+    /**
+     * The canonical world clock payload shared everywhere: Inertia props,
+     * broadcast events, and JSON responses. `server_now` lets clients compute a
+     * clock-skew offset so the timer counts down identically for everyone.
+     *
+     * @return array<string, mixed>
+     */
+    public static function payload(WorldClockSetting $setting): array
+    {
+        return [
+            'cities' => $setting->cities ?? [],
+            'face_preset' => $setting->face_preset,
+            'hand_preset' => $setting->hand_preset,
+            'numerals' => $setting->numerals,
+            'second_hand_mode' => $setting->second_hand_mode,
+            'logo' => $setting->logo ?? ['enabled' => false],
+            'timer_ends_at' => optional($setting->timer_ends_at)->toIso8601String(),
+            'server_now' => now()->toIso8601String(),
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,10 @@
 <?php
 
+use App\Exceptions\Handler;
+use App\Http\Kernel;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Application;
+
 /*
 |--------------------------------------------------------------------------
 | Create The Application
@@ -11,7 +16,7 @@
 |
 */
 
-$app = new Illuminate\Foundation\Application(
+$app = new Application(
     $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
 );
 
@@ -28,7 +33,7 @@ $app = new Illuminate\Foundation\Application(
 
 $app->singleton(
     Illuminate\Contracts\Http\Kernel::class,
-    App\Http\Kernel::class
+    Kernel::class
 );
 
 $app->singleton(
@@ -37,8 +42,8 @@ $app->singleton(
 );
 
 $app->singleton(
-    Illuminate\Contracts\Debug\ExceptionHandler::class,
-    App\Exceptions\Handler::class
+    ExceptionHandler::class,
+    Handler::class
 );
 
 /*

--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.381.2",
+            "version": "3.384.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ffa8a93faafea878155853ae2caf61871363869d"
+                "reference": "8e232a5703896541a7a34691a41ece5bd6170269"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ffa8a93faafea878155853ae2caf61871363869d",
-                "reference": "ffa8a93faafea878155853ae2caf61871363869d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/8e232a5703896541a7a34691a41ece5bd6170269",
+                "reference": "8e232a5703896541a7a34691a41ece5bd6170269",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.381.2"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.384.4"
             },
-            "time": "2026-05-15T18:08:57+00:00"
+            "time": "2026-06-05T18:05:57+00:00"
         },
         {
             "name": "barryvdh/laravel-dompdf",
@@ -1073,25 +1073,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
+                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1100,8 +1101,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.4",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1179,7 +1181,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
             },
             "funding": [
                 {
@@ -1195,28 +1197,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-02T12:40:51+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1262,7 +1265,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -1278,27 +1281,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1306,9 +1311,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1379,7 +1384,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -1395,20 +1400,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
                 "shasum": ""
             },
             "require": {
@@ -1417,7 +1422,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1465,7 +1470,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
             },
             "funding": [
                 {
@@ -1481,7 +1486,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-05-23T22:00:21+00:00"
         },
         {
             "name": "inertiajs/inertia-laravel",
@@ -1626,16 +1631,16 @@
         },
         {
             "name": "intervention/image",
-            "version": "4.1.0",
+            "version": "4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "fb795553f76afbe55c80d32b6bfe2090a6b1a0af"
+                "reference": "afe1f161df8a8fb46f354201328a4d9177dfcff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/fb795553f76afbe55c80d32b6bfe2090a6b1a0af",
-                "reference": "fb795553f76afbe55c80d32b6bfe2090a6b1a0af",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/afe1f161df8a8fb46f354201328a4d9177dfcff4",
+                "reference": "afe1f161df8a8fb46f354201328a4d9177dfcff4",
                 "shasum": ""
             },
             "require": {
@@ -1682,7 +1687,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/image/issues",
-                "source": "https://github.com/Intervention/image/tree/4.1.0"
+                "source": "https://github.com/Intervention/image/tree/4.1.3"
             },
             "funding": [
                 {
@@ -1698,7 +1703,7 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2026-05-15T06:52:36+00:00"
+            "time": "2026-06-03T13:21:10+00:00"
         },
         {
             "name": "intervention/image-laravel",
@@ -1786,16 +1791,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.9.0",
+            "version": "v13.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "a0c6ad03b380287015287d8d5a0fa2459e2332fd"
+                "reference": "e60b1c817a9ef7da319e4007de6cfda5301a58c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/a0c6ad03b380287015287d8d5a0fa2459e2332fd",
-                "reference": "a0c6ad03b380287015287d8d5a0fa2459e2332fd",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e60b1c817a9ef7da319e4007de6cfda5301a58c0",
+                "reference": "e60b1c817a9ef7da319e4007de6cfda5301a58c0",
                 "shasum": ""
             },
             "require": {
@@ -2006,20 +2011,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-13T15:38:40+00:00"
+            "time": "2026-06-04T18:46:35+00:00"
         },
         {
             "name": "laravel/nightwatch",
-            "version": "1.26.1",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/nightwatch.git",
-                "reference": "9212390822f80e6e3e4f399ad7818c551d94af71"
+                "reference": "229f082a5a4d760e4057c3acc1045ecec7e795bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/nightwatch/zipball/9212390822f80e6e3e4f399ad7818c551d94af71",
-                "reference": "9212390822f80e6e3e4f399ad7818c551d94af71",
+                "url": "https://api.github.com/repos/laravel/nightwatch/zipball/229f082a5a4d760e4057c3acc1045ecec7e795bc",
+                "reference": "229f082a5a4d760e4057c3acc1045ecec7e795bc",
                 "shasum": ""
             },
             "require": {
@@ -2100,20 +2105,20 @@
                 "issues": "https://github.com/laravel/nightwatch/issues",
                 "source": "https://github.com/laravel/nightwatch"
             },
-            "time": "2026-04-13T03:38:38+00:00"
+            "time": "2026-06-04T01:32:56+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.17",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -2157,9 +2162,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-04-20T16:07:33+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -3840,102 +3845,6 @@
             "time": "2026-02-16T23:10:27+00:00"
         },
         {
-            "name": "paragonie/sodium_compat",
-            "version": "v2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "4714da6efdc782c06690bc72ce34fae7941c2d9f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/4714da6efdc782c06690bc72ce34fae7941c2d9f",
-                "reference": "4714da6efdc782c06690bc72ce34fae7941c2d9f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1",
-                "php-64bit": "*"
-            },
-            "require-dev": {
-                "infection/infection": "^0",
-                "nikic/php-fuzzer": "^0",
-                "phpunit/phpunit": "^7|^8|^9|^10|^11",
-                "vimeo/psalm": "^4|^5|^6"
-            },
-            "suggest": {
-                "ext-sodium": "Better performance, password hashing (Argon2i), secure memory management (memzero), and better security."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "autoload.php"
-                ],
-                "psr-4": {
-                    "ParagonIE\\Sodium\\": "namespaced/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com"
-                },
-                {
-                    "name": "Frank Denis",
-                    "email": "jedisct1@pureftpd.org"
-                }
-            ],
-            "description": "Pure PHP implementation of libsodium; uses the PHP extension if it exists",
-            "keywords": [
-                "Authentication",
-                "BLAKE2b",
-                "ChaCha20",
-                "ChaCha20-Poly1305",
-                "Chapoly",
-                "Curve25519",
-                "Ed25519",
-                "EdDSA",
-                "Edwards-curve Digital Signature Algorithm",
-                "Elliptic Curve Diffie-Hellman",
-                "Poly1305",
-                "Pure-PHP cryptography",
-                "RFC 7748",
-                "RFC 8032",
-                "Salpoly",
-                "Salsa20",
-                "X25519",
-                "XChaCha20-Poly1305",
-                "XSalsa20-Poly1305",
-                "Xchacha20",
-                "Xsalsa20",
-                "aead",
-                "cryptography",
-                "ecdh",
-                "elliptic curve",
-                "elliptic curve cryptography",
-                "encryption",
-                "libsodium",
-                "php",
-                "public-key cryptography",
-                "secret-key cryptography",
-                "side-channel resistant"
-            ],
-            "support": {
-                "issues": "https://github.com/paragonie/sodium_compat/issues",
-                "source": "https://github.com/paragonie/sodium_compat/tree/v2.5.0"
-            },
-            "time": "2025-12-30T16:12:18+00:00"
-        },
-        {
             "name": "pbmedia/laravel-ffmpeg",
             "version": "8.9.0",
             "source": {
@@ -4719,16 +4628,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.22",
+            "version": "v0.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f"
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
-                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
                 "shasum": ""
             },
             "require": {
@@ -4792,29 +4701,28 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.22"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
             },
-            "time": "2026-03-22T23:03:24+00:00"
+            "time": "2026-05-23T13:41:31+00:00"
         },
         {
             "name": "pusher/pusher-php-server",
-            "version": "7.2.7",
+            "version": "7.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pusher/pusher-http-php.git",
-                "reference": "148b0b5100d000ed57195acdf548a2b1b38ee3f7"
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/148b0b5100d000ed57195acdf548a2b1b38ee3f7",
-                "reference": "148b0b5100d000ed57195acdf548a2b1b38ee3f7",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/4aa139ed2a2a805cd265449b691198beee1309d2",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "guzzlehttp/guzzle": "^7.2",
-                "paragonie/sodium_compat": "^1.6|^2.0",
                 "php": "^7.3|^8.0",
                 "psr/log": "^1.0|^2.0|^3.0"
             },
@@ -4853,9 +4761,9 @@
             ],
             "support": {
                 "issues": "https://github.com/pusher/pusher-http-php/issues",
-                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.7"
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
             },
-            "time": "2025-01-06T10:56:20+00:00"
+            "time": "2026-05-18T13:11:36+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -5516,16 +5424,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.4.10",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "8c5fbb4b5bc7a878f7ce66f1b7e29653c404984b"
+                "reference": "4c09e18a92cce126cc0d1155825279fca8cd0673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/8c5fbb4b5bc7a878f7ce66f1b7e29653c404984b",
-                "reference": "8c5fbb4b5bc7a878f7ce66f1b7e29653c404984b",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/4c09e18a92cce126cc0d1155825279fca8cd0673",
+                "reference": "4c09e18a92cce126cc0d1155825279fca8cd0673",
                 "shasum": ""
             },
             "require": {
@@ -5596,7 +5504,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.4.10"
+                "source": "https://github.com/symfony/cache/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5616,7 +5524,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T08:23:16+00:00"
+            "time": "2026-05-24T08:43:14+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -5778,16 +5686,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ed0107e43ab452aa77ae99e005b95e56b556e075",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -5852,7 +5760,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.11"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5872,7 +5780,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -6401,16 +6309,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -6459,7 +6367,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6479,20 +6387,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "eb9d68199af3fcfb3fb4d2e227367b68f8c1bb88"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/eb9d68199af3fcfb3fb4d2e227367b68f8c1bb88",
-                "reference": "eb9d68199af3fcfb3fb4d2e227367b68f8c1bb88",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -6578,7 +6486,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.11"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6598,20 +6506,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T17:55:00+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.8",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
                 "shasum": ""
             },
             "require": {
@@ -6662,7 +6570,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -6682,20 +6590,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/2d550c4758ba4c47519a6667c36553d535705b0c",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -6751,7 +6659,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.9"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6771,7 +6679,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T13:21:53+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6858,16 +6766,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -6916,7 +6824,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6936,20 +6844,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -7003,7 +6911,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7023,20 +6931,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -7088,7 +6996,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -7108,20 +7016,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -7173,7 +7081,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7193,7 +7101,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -7281,16 +7189,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -7337,7 +7245,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7357,20 +7265,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php82",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php82.git",
-                "reference": "34808efe3e68f69685796f7c253a2f1d8ea9df59"
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/34808efe3e68f69685796f7c253a2f1d8ea9df59",
-                "reference": "34808efe3e68f69685796f7c253a2f1d8ea9df59",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
                 "shasum": ""
             },
             "require": {
@@ -7417,7 +7325,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php82/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7437,20 +7345,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T16:19:22+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -7497,7 +7405,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7517,20 +7425,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -7577,7 +7485,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7597,20 +7505,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -7657,7 +7565,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7677,20 +7585,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-php86",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php86.git",
-                "reference": "33d8fc5a705481e21fe3a81212b26f9b1f61749c"
+                "reference": "fcec68d64f46dc84e1f6ffcf2c6dda40ff3143ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php86/zipball/33d8fc5a705481e21fe3a81212b26f9b1f61749c",
-                "reference": "33d8fc5a705481e21fe3a81212b26f9b1f61749c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php86/zipball/fcec68d64f46dc84e1f6ffcf2c6dda40ff3143ad",
+                "reference": "fcec68d64f46dc84e1f6ffcf2c6dda40ff3143ad",
                 "shasum": ""
             },
             "require": {
@@ -7737,7 +7645,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php86/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php86/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -7757,7 +7665,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-25T11:52:35+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -7844,16 +7752,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d9593c9efa40499eb078b81144de42cbc28a31f0"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d9593c9efa40499eb078b81144de42cbc28a31f0",
-                "reference": "d9593c9efa40499eb078b81144de42cbc28a31f0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -7885,7 +7793,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.11"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7905,20 +7813,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T16:55:21+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -7970,7 +7878,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.9"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7990,7 +7898,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8081,16 +7989,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
-                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -8148,7 +8056,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.11"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -8168,7 +8076,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
@@ -9023,16 +8931,16 @@
         },
         {
             "name": "web-token/jwt-library",
-            "version": "4.1.6",
+            "version": "4.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-library.git",
-                "reference": "e8ab00927a3856f3f0c8218226382cd6a58928a1"
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/e8ab00927a3856f3f0c8218226382cd6a58928a1",
-                "reference": "e8ab00927a3856f3f0c8218226382cd6a58928a1",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
                 "shasum": ""
             },
             "require": {
@@ -9096,7 +9004,7 @@
             ],
             "support": {
                 "issues": "https://github.com/web-token/jwt-library/issues",
-                "source": "https://github.com/web-token/jwt-library/tree/4.1.6"
+                "source": "https://github.com/web-token/jwt-library/tree/4.1.7"
             },
             "funding": [
                 {
@@ -9108,7 +9016,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-04-14T07:44:20+00:00"
+            "time": "2026-06-06T18:12:39+00:00"
         }
     ],
     "packages-dev": [
@@ -9299,16 +9207,16 @@
         },
         {
             "name": "laravel/breeze",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/breeze.git",
-                "reference": "28cefeaf6af20177ddf5cc7b93e87e4ad79d533f"
+                "reference": "4f20e7b2cc8d25daa85d8647241a89c8e0930305"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/breeze/zipball/28cefeaf6af20177ddf5cc7b93e87e4ad79d533f",
-                "reference": "28cefeaf6af20177ddf5cc7b93e87e4ad79d533f",
+                "url": "https://api.github.com/repos/laravel/breeze/zipball/4f20e7b2cc8d25daa85d8647241a89c8e0930305",
+                "reference": "4f20e7b2cc8d25daa85d8647241a89c8e0930305",
                 "shasum": ""
             },
             "require": {
@@ -9356,7 +9264,7 @@
                 "issues": "https://github.com/laravel/breeze/issues",
                 "source": "https://github.com/laravel/breeze"
             },
-            "time": "2026-03-10T19:59:01+00:00"
+            "time": "2026-05-14T16:54:25+00:00"
         },
         {
             "name": "laravel/pint",
@@ -9428,16 +9336,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.59.0",
+            "version": "v1.62.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "a41abad557e487eaefde6c9873085ed086fdf47a"
+                "reference": "3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/a41abad557e487eaefde6c9873085ed086fdf47a",
-                "reference": "a41abad557e487eaefde6c9873085ed086fdf47a",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e",
+                "reference": "3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e",
                 "shasum": ""
             },
             "require": {
@@ -9487,7 +9395,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-05-13T14:02:20+00:00"
+            "time": "2026-05-27T04:02:01+00:00"
         },
         {
             "name": "mmo/faker-images",
@@ -9904,16 +9812,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.6",
+            "version": "12.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691"
+                "reference": "186dab580576598076de6818596d12b61801880e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
                 "shasum": ""
             },
             "require": {
@@ -9924,13 +9832,13 @@
                 "php": ">=8.3",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/lines-of-code": "^4.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
                 "sebastian/version": "^6.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.1"
+                "phpunit/phpunit": "^12.5.28"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -9968,7 +9876,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
             },
             "funding": [
                 {
@@ -9988,7 +9896,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T08:23:17+00:00"
+            "time": "2026-06-01T13:24:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -10249,16 +10157,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.25",
+            "version": "12.5.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "792c2980442dfce319226b88fa845b8b6de3b333"
+                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/792c2980442dfce319226b88fa845b8b6de3b333",
-                "reference": "792c2980442dfce319226b88fa845b8b6de3b333",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9aa66a47db3ea70f1a468e66dd969f67e594945a",
+                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a",
                 "shasum": ""
             },
             "require": {
@@ -10272,20 +10180,20 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-code-coverage": "^12.5.7",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.6",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.1.0",
-                "sebastian/exporter": "^7.0.2",
-                "sebastian/global-state": "^8.0.2",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
+                "sebastian/global-state": "^8.0.3",
                 "sebastian/object-enumerator": "^7.0.0",
                 "sebastian/recursion-context": "^7.0.1",
-                "sebastian/type": "^6.0.3",
+                "sebastian/type": "^6.0.4",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
             },
@@ -10327,7 +10235,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.29"
             },
             "funding": [
                 {
@@ -10335,27 +10243,27 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-13T03:56:57+00:00"
+            "time": "2026-06-04T06:14:42+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -10384,7 +10292,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
             },
             "funding": [
                 {
@@ -10404,20 +10312,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T09:36:45+00:00"
+            "time": "2026-05-17T05:29:34+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.6",
+            "version": "7.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
-                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
                 "shasum": ""
             },
             "require": {
@@ -10425,10 +10333,10 @@
                 "ext-mbstring": "*",
                 "php": ">=8.3",
                 "sebastian/diff": "^7.0",
-                "sebastian/exporter": "^7.0"
+                "sebastian/exporter": "^7.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.2"
+                "phpunit/phpunit": "^12.5.25"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -10476,7 +10384,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
             },
             "funding": [
                 {
@@ -10496,7 +10404,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-14T08:23:15+00:00"
+            "time": "2026-05-21T04:45:25+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -10625,23 +10533,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.1.0",
+            "version": "8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
-                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.26"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -10677,7 +10585,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
             },
             "funding": [
                 {
@@ -10697,29 +10605,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:13:01+00:00"
+            "time": "2026-05-25T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.2",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": ">=8.3",
-                "sebastian/recursion-context": "^7.0"
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -10767,7 +10675,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
             },
             "funding": [
                 {
@@ -10787,30 +10695,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:16:11+00:00"
+            "time": "2026-05-20T04:37:17+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3",
                 "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.28"
             },
             "type": "library",
             "extra": {
@@ -10841,7 +10749,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
             },
             "funding": [
                 {
@@ -10861,28 +10769,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T11:29:25+00:00"
+            "time": "2026-06-01T15:10:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -10911,15 +10819,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:57:28+00:00"
+            "time": "2026-05-19T16:22:07+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -11113,23 +11033,23 @@
         },
         {
             "name": "sebastian/type",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -11158,7 +11078,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
             },
             "funding": [
                 {
@@ -11178,7 +11098,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:57:12+00:00"
+            "time": "2026-05-20T06:45:45+00:00"
         },
         {
             "name": "sebastian/version",
@@ -11673,16 +11593,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e2eb64a57763815ccae07ac1c7653d6cc1c326fd"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e2eb64a57763815ccae07ac1c7653d6cc1c326fd",
-                "reference": "e2eb64a57763815ccae07ac1c7653d6cc1c326fd",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
@@ -11725,7 +11645,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.11"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -11745,7 +11665,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/app.php
+++ b/config/app.php
@@ -1,6 +1,32 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\EventServiceProvider;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Auth\AuthServiceProvider;
+use Illuminate\Auth\Passwords\PasswordResetServiceProvider;
+use Illuminate\Broadcasting\BroadcastServiceProvider;
+use Illuminate\Bus\BusServiceProvider;
+use Illuminate\Cache\CacheServiceProvider;
+use Illuminate\Cookie\CookieServiceProvider;
+use Illuminate\Database\DatabaseServiceProvider;
+use Illuminate\Encryption\EncryptionServiceProvider;
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Foundation\Providers\ConsoleSupportServiceProvider;
+use Illuminate\Foundation\Providers\FoundationServiceProvider;
+use Illuminate\Hashing\HashServiceProvider;
+use Illuminate\Mail\MailServiceProvider;
+use Illuminate\Notifications\NotificationServiceProvider;
+use Illuminate\Pagination\PaginationServiceProvider;
+use Illuminate\Pipeline\PipelineServiceProvider;
+use Illuminate\Queue\QueueServiceProvider;
+use Illuminate\Redis\RedisServiceProvider;
+use Illuminate\Session\SessionServiceProvider;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\TranslationServiceProvider;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\View\ViewServiceProvider;
+use Spatie\Permission\PermissionServiceProvider;
 
 return [
 
@@ -159,42 +185,42 @@ return [
         /*
          * Laravel Framework Service Providers...
          */
-        Illuminate\Auth\AuthServiceProvider::class,
-        Illuminate\Broadcasting\BroadcastServiceProvider::class,
-        Illuminate\Bus\BusServiceProvider::class,
-        Illuminate\Cache\CacheServiceProvider::class,
-        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
-        Illuminate\Cookie\CookieServiceProvider::class,
-        Illuminate\Database\DatabaseServiceProvider::class,
-        Illuminate\Encryption\EncryptionServiceProvider::class,
-        Illuminate\Filesystem\FilesystemServiceProvider::class,
-        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
-        Illuminate\Hashing\HashServiceProvider::class,
-        Illuminate\Mail\MailServiceProvider::class,
-        Illuminate\Notifications\NotificationServiceProvider::class,
-        Illuminate\Pagination\PaginationServiceProvider::class,
-        Illuminate\Pipeline\PipelineServiceProvider::class,
-        Illuminate\Queue\QueueServiceProvider::class,
-        Illuminate\Redis\RedisServiceProvider::class,
-        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
-        Illuminate\Session\SessionServiceProvider::class,
-        Illuminate\Translation\TranslationServiceProvider::class,
-        Illuminate\Validation\ValidationServiceProvider::class,
-        Illuminate\View\ViewServiceProvider::class,
+        AuthServiceProvider::class,
+        BroadcastServiceProvider::class,
+        BusServiceProvider::class,
+        CacheServiceProvider::class,
+        ConsoleSupportServiceProvider::class,
+        CookieServiceProvider::class,
+        DatabaseServiceProvider::class,
+        EncryptionServiceProvider::class,
+        FilesystemServiceProvider::class,
+        FoundationServiceProvider::class,
+        HashServiceProvider::class,
+        MailServiceProvider::class,
+        NotificationServiceProvider::class,
+        PaginationServiceProvider::class,
+        PipelineServiceProvider::class,
+        QueueServiceProvider::class,
+        RedisServiceProvider::class,
+        PasswordResetServiceProvider::class,
+        SessionServiceProvider::class,
+        TranslationServiceProvider::class,
+        ValidationServiceProvider::class,
+        ViewServiceProvider::class,
 
         /*
          * Package Service Providers...
          */
-        Spatie\Permission\PermissionServiceProvider::class,
+        PermissionServiceProvider::class,
 
         /*
          * Application Service Providers...
          */
-        App\Providers\AppServiceProvider::class,
+        AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         App\Providers\BroadcastServiceProvider::class,
-        App\Providers\EventServiceProvider::class,
-        App\Providers\RouteServiceProvider::class,
+        EventServiceProvider::class,
+        RouteServiceProvider::class,
 
     ],
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -62,7 +64,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => App\Models\User::class,
+            'model' => User::class,
         ],
 
         // 'users' => [

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,5 +1,8 @@
 <?php
 
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
 return [
 
     'models' => [
@@ -13,7 +16,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -24,7 +27,7 @@ return [
          * `Spatie\Permission\Contracts\Role` contract.
          */
 
-        'role' => Spatie\Permission\Models\Role::class,
+        'role' => Role::class,
 
     ],
 
@@ -167,7 +170,7 @@ return [
          * When permissions or roles are updated the cache is flushed automatically.
          */
 
-        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
 
         /*
          * The cache key used to store all permissions.

--- a/database/factories/BookFactory.php
+++ b/database/factories/BookFactory.php
@@ -2,10 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Book;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Book>
+ * @extends Factory<Book>
  */
 class BookFactory extends Factory
 {

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -2,10 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Category;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ * @extends Factory<Category>
  */
 class CategoryFactory extends Factory
 {

--- a/database/factories/CollageFactory.php
+++ b/database/factories/CollageFactory.php
@@ -2,10 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Collage;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Collage>
+ * @extends Factory<Collage>
  */
 class CollageFactory extends Factory
 {

--- a/database/factories/CommentReactionFactory.php
+++ b/database/factories/CommentReactionFactory.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CommentReaction>
+ * @extends Factory<CommentReaction>
  */
 class CommentReactionFactory extends Factory
 {

--- a/database/factories/MessageCommentFactory.php
+++ b/database/factories/MessageCommentFactory.php
@@ -3,11 +3,12 @@
 namespace Database\Factories;
 
 use App\Models\Message;
+use App\Models\MessageComment;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\MessageComment>
+ * @extends Factory<MessageComment>
  */
 class MessageCommentFactory extends Factory
 {

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -2,11 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Message;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Message>
+ * @extends Factory<Message>
  */
 class MessageFactory extends Factory
 {

--- a/database/factories/MessageReactionFactory.php
+++ b/database/factories/MessageReactionFactory.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\MessageReaction>
+ * @extends Factory<MessageReaction>
  */
 class MessageReactionFactory extends Factory
 {

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -3,11 +3,12 @@
 namespace Database\Factories;
 
 use App\Models\Book;
+use App\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Mmo\Faker\PicsumProvider;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Page>
+ * @extends Factory<Page>
  */
 class PageFactory extends Factory
 {

--- a/database/factories/SongFactory.php
+++ b/database/factories/SongFactory.php
@@ -6,7 +6,7 @@ use App\Models\Song;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Song>
+ * @extends Factory<Song>
  */
 class SongFactory extends Factory
 {

--- a/database/factories/SoundFactory.php
+++ b/database/factories/SoundFactory.php
@@ -6,7 +6,7 @@ use App\Models\Sound;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Sound>
+ * @extends Factory<Sound>
  */
 class SoundFactory extends Factory
 {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,11 +2,14 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {
@@ -47,10 +50,10 @@ class UserFactory extends Factory
     {
         return $this->afterCreating(function ($user) {
             // Create the admin permission if it doesn't exist
-            $adminPermission = \Spatie\Permission\Models\Permission::firstOrCreate(['name' => 'admin']);
+            $adminPermission = Permission::firstOrCreate(['name' => 'admin']);
 
             // Create the admin role if it doesn't exist
-            $adminRole = \Spatie\Permission\Models\Role::firstOrCreate(['name' => 'admin']);
+            $adminRole = Role::firstOrCreate(['name' => 'admin']);
 
             // Give the admin role the admin permission
             $adminRole->givePermissionTo($adminPermission);

--- a/database/migrations/2022_05_08_041243_create_permission_tables.php
+++ b/database/migrations/2022_05_08_041243_create_permission_tables.php
@@ -18,10 +18,10 @@ return new class extends Migration
         $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
 
         if (empty($tableNames)) {
-            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+            throw new Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
         }
         if ($teams && empty($columnNames['team_foreign_key'] ?? null)) {
-            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+            throw new Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
         }
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
@@ -126,7 +126,7 @@ return new class extends Migration
         $tableNames = config('permission.table_names');
 
         if (empty($tableNames)) {
-            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+            throw new Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
         }
 
         Schema::drop($tableNames['role_has_permissions']);

--- a/database/migrations/2022_05_11_040732_create_pages_table.php
+++ b/database/migrations/2022_05_11_040732_create_pages_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Book;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +16,7 @@ return new class extends Migration
     {
         Schema::create('pages', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(\App\Models\Book::class);
+            $table->foreignIdFor(Book::class);
             $table->longText('content')->nullable();
             $table->string('image_path')->nullable();
             $table->timestamps();

--- a/database/migrations/2026_04_08_000001_drop_page_id_unique_from_collage_page_table.php
+++ b/database/migrations/2026_04_08_000001_drop_page_id_unique_from_collage_page_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             Schema::table('collage_page', function (Blueprint $table) {
                 $table->dropUnique('collage_page_page_id_unique');
             });
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $message = strtolower($e->getMessage());
 
             if (

--- a/database/migrations/2026_06_06_000000_create_world_clock_settings_table.php
+++ b/database/migrations/2026_06_06_000000_create_world_clock_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('world_clock_settings', function (Blueprint $table) {
+            $table->id();
+            $table->json('cities')->nullable();              // [{name,timezone,country}]
+            $table->string('face_preset')->default('theme');
+            $table->string('hand_preset')->default('classic');
+            $table->string('numerals')->default('arabic');
+            $table->string('second_hand_mode')->default('smooth');
+            $table->json('logo')->nullable();                // {enabled,cityName,timezone,facePreset,handPreset,numerals}
+            $table->timestamp('timer_ends_at')->nullable();  // absolute expiry; null = no timer
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('world_clock_settings');
+    }
+};

--- a/database/migrations/2026_06_06_000000_create_world_clock_settings_table.php
+++ b/database/migrations/2026_06_06_000000_create_world_clock_settings_table.php
@@ -10,6 +10,7 @@ return new class extends Migration
     {
         Schema::create('world_clock_settings', function (Blueprint $table) {
             $table->id();
+            $table->string('key')->unique()->default('global'); // singleton key
             $table->json('cities')->nullable();              // [{name,timezone,country}]
             $table->string('face_preset')->default('theme');
             $table->string('hand_preset')->default('classic');

--- a/database/migrations/2026_06_06_000000_create_world_clock_settings_table.php
+++ b/database/migrations/2026_06_06_000000_create_world_clock_settings_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->string('hand_preset')->default('classic');
             $table->string('numerals')->default('arabic');
             $table->string('second_hand_mode')->default('smooth');
-            $table->json('logo')->nullable();                // {enabled,cityName,timezone,facePreset,handPreset,numerals}
+            $table->json('logo')->nullable();                // {enabled,cityName,timezone}
             $table->timestamp('timer_ends_at')->nullable();  // absolute expiry; null = no timer
             $table->timestamps();
         });

--- a/resources/js/Components/ApplicationLogo.vue
+++ b/resources/js/Components/ApplicationLogo.vue
@@ -4,9 +4,9 @@
         :timezone="logo.timezone"
         :city-name="logo.cityName"
         size="100%"
-        :face-preset="logo.facePreset"
-        :hand-preset="logo.handPreset"
-        :numerals="logo.numerals"
+        :face-preset="state.facePreset"
+        :hand-preset="state.handPreset"
+        :numerals="state.numerals"
         :show-seconds="true"
         second-hand-mode="tick"
     />
@@ -630,6 +630,7 @@
 <script setup>
 import AnalogClock from "@/Components/WorldClock/AnalogClock.vue";
 import { useLogoPreference } from "@/composables/useLogoPreference";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 import { usePage } from "@inertiajs/vue3";
 import { computed } from "vue";
 
@@ -639,4 +640,7 @@ const isJuly = computed(() => page.props.theme === "fireworks");
 const isHalloween = computed(() => page.props.theme === "halloween");
 
 const { logo } = useLogoPreference();
+// The logo clock uses the shared global appearance so it matches the other
+// clocks; the logo itself only records which city is pinned.
+const { state } = useWorldClockSync();
 </script>

--- a/resources/js/Components/WorldClock/AnalogClock.test.js
+++ b/resources/js/Components/WorldClock/AnalogClock.test.js
@@ -4,11 +4,14 @@ import { mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { nextTick } from "vue";
 
-const sync = useWorldClockSync();
+let sync;
 
 // Set (or clear) the shared timer end time the way the server would, then let
 // the countdown watcher react.
 const setTimer = async (secondsFromNow) => {
+  if (!sync) {
+    sync = useWorldClockSync();
+  }
   const now = new Date();
   sync.applyRemote({
     timer_ends_at:

--- a/resources/js/Components/WorldClock/AnalogClock.test.js
+++ b/resources/js/Components/WorldClock/AnalogClock.test.js
@@ -1,9 +1,25 @@
 import AnalogClock from "@/Components/WorldClock/AnalogClock.vue";
-import { useGlobalTimer } from "@/composables/useGlobalTimer";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 import { mount } from "@vue/test-utils";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
 
-const timer = useGlobalTimer();
+const sync = useWorldClockSync();
+
+// Set (or clear) the shared timer end time the way the server would, then let
+// the countdown watcher react.
+const setTimer = async (secondsFromNow) => {
+  const now = new Date();
+  sync.applyRemote({
+    timer_ends_at:
+      secondsFromNow == null
+        ? null
+        : new Date(now.getTime() + secondsFromNow * 1000).toISOString(),
+    server_now: now.toISOString()
+  });
+  await nextTick();
+  await nextTick();
+};
 
 describe("Components/WorldClock/AnalogClock.vue", () => {
   it("renders Roman numerals when numerals='roman'", () => {
@@ -52,24 +68,31 @@ describe("Components/WorldClock/AnalogClock.vue", () => {
     expect(rotated.length).toBe(2);
   });
 
-  afterEach(() => timer.stop());
+  beforeEach(() => {
+    window.Echo = {
+      socketId: () => "socket-123",
+      private: () => ({ listen: () => {} })
+    };
+  });
 
-  it("renders no timer wedge when the global timer is inactive", () => {
-    timer.stop();
+  afterEach(() => setTimer(null));
+
+  it("renders no timer wedge when the global timer is inactive", async () => {
+    await setTimer(null);
     const wrapper = mount(AnalogClock, { props: { timezone: "UTC" } });
     expect(wrapper.findAll('[fill="#b91c1c"]').length).toBe(0);
   });
 
-  it("renders a partial deep-red wedge (path) for a fractional timer", () => {
-    timer.start(15 * 60);
+  it("renders a partial deep-red wedge (path) for a fractional timer", async () => {
+    await setTimer(15 * 60);
     const wrapper = mount(AnalogClock, { props: { timezone: "UTC" } });
     const wedges = wrapper.findAll('[fill="#b91c1c"]');
     expect(wedges.length).toBe(1);
     expect(wedges[0].element.tagName.toLowerCase()).toBe("path");
   });
 
-  it("renders a full deep-red disk (circle) when the timer fills the hour", () => {
-    timer.start(60 * 60);
+  it("renders a full deep-red disk (circle) when the timer fills the hour", async () => {
+    await setTimer(60 * 60 + 10);
     const wrapper = mount(AnalogClock, { props: { timezone: "UTC" } });
     const wedges = wrapper.findAll('[fill="#b91c1c"]');
     expect(wedges.length).toBe(1);

--- a/resources/js/Components/WorldClock/ClockCard.vue
+++ b/resources/js/Components/WorldClock/ClockCard.vue
@@ -28,10 +28,7 @@ const isLogo = computed(
 const setAsLogo = () => {
   setLogoClock({
     cityName: props.city.name,
-    timezone: props.city.timezone,
-    facePreset: props.facePreset,
-    handPreset: props.handPreset,
-    numerals: props.numerals
+    timezone: props.city.timezone
   });
   emit("speak", `${props.city.name} clock set as the app logo`);
 };

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -16,16 +16,11 @@ usePusherNotifications();
 const page = usePage();
 const { playSong, openFlyout } = useMusicPlayer();
 
-// Seed the shared World Clock state app-wide so the nav logo clock and the
-// shared timer work on every page. The prop refreshes on each navigation.
+// Seed the shared World Clock state app-wide (once) so the nav logo clock and
+// the shared timer work on every page. Live updates arrive via Echo; a full
+// page refresh re-seeds from the server, keeping every session consistent.
 const worldClockSync = useWorldClockSync();
 if (page.props.worldClock) worldClockSync.hydrate(page.props.worldClock);
-watch(
-  () => page.props.worldClock,
-  (wc) => {
-    if (wc) worldClockSync.hydrate(wc);
-  }
-);
 
 async function playSongFromFlash(songId) {
   if (songId == null || songId === "") return;

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -5,6 +5,7 @@ import SearchInput from "@/Components/SearchInput.vue";
 import { useMusicPlayer } from "@/composables/useMusicPlayer";
 import { usePusherNotifications } from "@/composables/usePusherNotifications";
 import { usePushNotifications } from "@/composables/usePushNotifications";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 import Footer from "@/Layouts/Nav/Footer.vue";
 import Navigation from "@/Layouts/Nav/Navigation.vue";
 import { usePage } from "@inertiajs/vue3";
@@ -14,6 +15,17 @@ usePusherNotifications();
 
 const page = usePage();
 const { playSong, openFlyout } = useMusicPlayer();
+
+// Seed the shared World Clock state app-wide so the nav logo clock and the
+// shared timer work on every page. The prop refreshes on each navigation.
+const worldClockSync = useWorldClockSync();
+if (page.props.worldClock) worldClockSync.hydrate(page.props.worldClock);
+watch(
+  () => page.props.worldClock,
+  (wc) => {
+    if (wc) worldClockSync.hydrate(wc);
+  }
+);
 
 async function playSongFromFlash(songId) {
   if (songId == null || songId === "") return;

--- a/resources/js/Pages/WorldClock/Index.vue
+++ b/resources/js/Pages/WorldClock/Index.vue
@@ -5,17 +5,19 @@ import CityPicker from "@/Components/WorldClock/CityPicker.vue";
 import ClockCustomizer from "@/Components/WorldClock/ClockCustomizer.vue";
 import WorldClockGrid from "@/Components/WorldClock/WorldClockGrid.vue";
 import { useWorldClockPreferences } from "@/composables/useWorldClockPreferences";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 import { Head } from "@inertiajs/vue3";
 
 const props = defineProps({
   defaultCities: { type: Array, default: () => [] },
-  maxCities: { type: Number, default: 6 }
+  maxCities: { type: Number, default: 6 },
+  worldClock: { type: Object, default: null }
 });
 
-const { prefs, addCity, removeCity } = useWorldClockPreferences(
-  props.defaultCities,
-  props.maxCities
-);
+// Seed the shared state from this page's server props before reading it.
+if (props.worldClock) useWorldClockSync().hydrate(props.worldClock);
+
+const { prefs, addCity, removeCity } = useWorldClockPreferences(props.maxCities);
 
 // Settings start expanded on desktop and collapsed on mobile, so phones lead
 // with the clocks themselves.

--- a/resources/js/composables/useGlobalTimer.js
+++ b/resources/js/composables/useGlobalTimer.js
@@ -93,9 +93,17 @@ const fraction = computed(() => Math.min(1, remainingMs.value / HOUR_MS));
 export function useGlobalTimer() {
   const sync = useWorldClockSync();
 
-  const start = (seconds) =>
-    sync.push("world-clock.timer.start", "post", { seconds });
-  const stop = () => sync.push("world-clock.timer.stop", "delete");
+  // Reconcile only the timer fields from the response so we pick up the
+  // server's authoritative end time + clock offset without disturbing any
+  // unsaved appearance/city edits.
+  const start = async (seconds) => {
+    const data = await sync.push("world-clock.timer.start", "post", { seconds });
+    sync.reconcileTimer(data);
+  };
+  const stop = async () => {
+    const data = await sync.push("world-clock.timer.stop", "delete");
+    sync.reconcileTimer(data);
+  };
 
   return { active, remainingMs, remainingSeconds, fraction, start, stop };
 }

--- a/resources/js/composables/useGlobalTimer.js
+++ b/resources/js/composables/useGlobalTimer.js
@@ -1,17 +1,28 @@
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 
-// A single shared countdown timer for the whole app. Every clock (including the
-// nav logo clock) reads this same state, so the red timer pie is identical
-// everywhere. Module-level singleton — controls live in one place (the World
-// Clock customizer) but the visual applies to all clocks.
+// A single shared countdown timer for the whole app, backed by the global server
+// state (see useWorldClockSync). The timer is stored as an absolute end time, so
+// when one user starts it every client derives the same countdown — corrected by
+// the server-time offset so clock skew doesn't matter. The red timer pie is
+// therefore identical for everyone, on every page.
 
 const HOUR_MS = 60 * 60 * 1000;
 
-const endTime = ref(0);
+const { state, serverOffsetMs } = useWorldClockSync();
+
 const remainingMs = ref(0);
 const active = ref(false);
 let intervalId = null;
-let completed = false;
+// The end time we've already announced "Time's up!" for, so each timer fires the
+// announcement exactly once even after a reconcile re-applies the same state.
+let announcedFor = 0;
+
+const endMs = () => {
+  if (!state.timerEndsAt) return 0;
+  const parsed = Date.parse(state.timerEndsAt);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
 
 const clear = () => {
   if (intervalId !== null) {
@@ -20,9 +31,8 @@ const clear = () => {
   }
 };
 
-// Speak "Time's up!" using the user's stored speech settings, independent of
-// any mounted component so it fires even when the timer finishes on another
-// page (the logo clock keeps the timer visible app-wide).
+// Speak "Time's up!" using the user's stored speech settings, independent of any
+// mounted component so it fires even when the timer finishes on another page.
 const announce = (text) => {
   if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
   try {
@@ -40,37 +50,52 @@ const announce = (text) => {
 };
 
 const update = () => {
-  const rem = Math.max(0, endTime.value - Date.now());
-  remainingMs.value = rem;
-  if (rem <= 0 && active.value) {
+  const end = endMs();
+  if (!end) {
+    remainingMs.value = 0;
     active.value = false;
     clear();
-    if (!completed) {
-      completed = true;
+    return;
+  }
+  const serverNow = Date.now() + serverOffsetMs.value;
+  const rem = Math.max(0, end - serverNow);
+  remainingMs.value = rem;
+  if (rem <= 0) {
+    active.value = false;
+    clear();
+    if (announcedFor !== end) {
+      announcedFor = end;
       announce("Time's up!");
     }
+  } else {
+    active.value = true;
   }
 };
 
-const start = (seconds) => {
-  completed = false;
-  endTime.value = Date.now() + seconds * 1000;
-  remainingMs.value = seconds * 1000;
-  active.value = true;
-  clear();
-  intervalId = setInterval(update, 250);
-};
-
-const stop = () => {
-  active.value = false;
-  completed = false;
-  remainingMs.value = 0;
-  clear();
-};
+// Drive the countdown whenever the shared end time changes (a timer started or
+// stopped by anyone). A single interval keeps every clock in sync.
+watch(
+  () => state.timerEndsAt,
+  () => {
+    const end = endMs();
+    // Allow a fresh timer (or a re-used duration) to announce again.
+    if (end && end > Date.now() + serverOffsetMs.value) announcedFor = 0;
+    clear();
+    update();
+    if (active.value) intervalId = setInterval(update, 250);
+  },
+  { immediate: true }
+);
 
 const remainingSeconds = computed(() => Math.ceil(remainingMs.value / 1000));
 const fraction = computed(() => Math.min(1, remainingMs.value / HOUR_MS));
 
 export function useGlobalTimer() {
+  const sync = useWorldClockSync();
+
+  const start = (seconds) =>
+    sync.push("world-clock.timer.start", "post", { seconds });
+  const stop = () => sync.push("world-clock.timer.stop", "delete");
+
   return { active, remainingMs, remainingSeconds, fraction, start, stop };
 }

--- a/resources/js/composables/useGlobalTimer.test.js
+++ b/resources/js/composables/useGlobalTimer.test.js
@@ -1,38 +1,64 @@
 import { useGlobalTimer } from "@/composables/useGlobalTimer";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+// Drive the shared end time the way the server would, so the timer derives its
+// countdown from it. server_now == current time means a zero clock-skew offset.
+const setTimer = (sync, msFromNow) => {
+  const now = new Date();
+  sync.applyRemote({
+    timer_ends_at:
+      msFromNow == null ? null : new Date(now.getTime() + msFromNow).toISOString(),
+    server_now: now.toISOString()
+  });
+};
 
 describe("composables/useGlobalTimer", () => {
-  beforeEach(() => {
+  let sync;
+
+  beforeEach(async () => {
+    window.Echo = {
+      socketId: () => "socket-123",
+      private: () => ({ listen: () => {} })
+    };
+    sync = useWorldClockSync();
+    setTimer(sync, null);
+    await nextTick();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
     window.speechSynthesis.speak.mockClear();
-    useGlobalTimer().stop();
   });
 
   afterEach(() => {
-    useGlobalTimer().stop();
     vi.useRealTimers();
   });
 
-  it("is a shared singleton across calls", () => {
+  it("is a shared singleton across calls", async () => {
     const a = useGlobalTimer();
     const b = useGlobalTimer();
-    a.start(30 * 60);
+    setTimer(sync, 30 * 60 * 1000);
+    await nextTick();
+    await nextTick();
     expect(b.active.value).toBe(true);
-    expect(b.fraction.value).toBeCloseTo(0.5, 2);
+    expect(a.fraction.value).toBeCloseTo(0.5, 2);
   });
 
-  it("shrinks the fraction as time elapses", () => {
+  it("shrinks the fraction as time elapses", async () => {
     const t = useGlobalTimer();
-    t.start(60 * 60);
+    setTimer(sync, 60 * 60 * 1000);
+    await nextTick();
+    await nextTick();
     expect(t.fraction.value).toBeCloseTo(1, 2);
     vi.advanceTimersByTime(30 * 60 * 1000);
     expect(t.fraction.value).toBeCloseTo(0.5, 1);
   });
 
-  it("announces once and goes inactive at zero", () => {
+  it("announces once and goes inactive at zero", async () => {
     const t = useGlobalTimer();
-    t.start(15 * 60);
+    setTimer(sync, 15 * 60 * 1000);
+    await nextTick();
+    await nextTick();
     vi.advanceTimersByTime(15 * 60 * 1000);
     expect(t.active.value).toBe(false);
     expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
@@ -40,12 +66,40 @@ describe("composables/useGlobalTimer", () => {
     expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
   });
 
-  it("stop() halts the timer without announcing", () => {
+  it("clearing the shared timer halts it without announcing", async () => {
     const t = useGlobalTimer();
-    t.start(30 * 60);
-    t.stop();
+    setTimer(sync, 30 * 60 * 1000);
+    await nextTick();
+    await nextTick();
+    setTimer(sync, null);
+    await nextTick();
+    await nextTick();
     expect(t.active.value).toBe(false);
     vi.advanceTimersByTime(30 * 60 * 1000);
     expect(window.speechSynthesis.speak).not.toHaveBeenCalled();
+  });
+
+  it("start and stop push to the server", async () => {
+    vi.useRealTimers();
+    window.axios = {
+      request: vi.fn().mockResolvedValue({
+        data: { timer_ends_at: null, server_now: new Date().toISOString() }
+      })
+    };
+    const { start, stop } = useGlobalTimer();
+
+    await start(300);
+    expect(window.axios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/world-clock/timer",
+        method: "post",
+        data: { seconds: 300 }
+      })
+    );
+
+    await stop();
+    expect(window.axios.request).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "/api/world-clock/timer", method: "delete" })
+    );
   });
 });

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -1,46 +1,14 @@
-import { reactive, toRaw, watch } from "vue";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 
-// Lets the user replace the top-left nav logo with a configured clock. State is
-// a module-level singleton reactive object so a write from the World Clock page
-// is reflected live in the nav (localStorage alone is not cross-component
-// reactive). The choice persists in localStorage across reloads.
-
-const STORAGE_KEY = "shudderfly.worldClock.logo";
-
-const DEFAULT = {
-  enabled: false,
-  cityName: "",
-  timezone: "",
-  facePreset: "theme",
-  handPreset: "classic",
-  numerals: "none"
-};
-
-const logo = reactive({ ...DEFAULT });
-
-try {
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored) {
-    const parsed = JSON.parse(stored);
-    if (parsed && typeof parsed === "object") Object.assign(logo, parsed);
-  }
-} catch (e) {
-  console.error("Error loading logo preference:", e);
-}
-
-watch(
-  logo,
-  () => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(toRaw(logo)));
-    } catch (e) {
-      console.error("Error saving logo preference:", e);
-    }
-  },
-  { deep: true }
-);
+// Lets users replace the top-left nav logo with a configured clock. The choice
+// is now part of the shared server state (see useWorldClockSync), so the same
+// logo clock shows for everyone. `logo` is the live shared object — mutated in
+// place so the nav logo updates app-wide. Public API is unchanged.
 
 export function useLogoPreference() {
+  const sync = useWorldClockSync();
+  const logo = sync.state.logo;
+
   function setLogoClock(config) {
     Object.assign(logo, {
       enabled: true,
@@ -50,10 +18,19 @@ export function useLogoPreference() {
       handPreset: config.handPreset || "classic",
       numerals: config.numerals || "none"
     });
+    sync.push("world-clock.logo.update", "put", { ...logo });
   }
 
   function clearLogoClock() {
-    Object.assign(logo, { ...DEFAULT });
+    Object.assign(logo, {
+      enabled: false,
+      cityName: "",
+      timezone: "",
+      facePreset: "theme",
+      handPreset: "classic",
+      numerals: "none"
+    });
+    sync.push("world-clock.logo.update", "put", { ...logo });
   }
 
   return { logo, setLogoClock, clearLogoClock };

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -11,18 +11,26 @@ export function useLogoPreference() {
   const sync = useWorldClockSync();
   const logo = sync.state.logo;
 
+  function logoPayload() {
+    return {
+      enabled: logo.enabled,
+      cityName: logo.cityName,
+      timezone: logo.timezone
+    };
+  }
+
   function setLogoClock(config) {
     Object.assign(logo, {
       enabled: true,
       cityName: config.cityName || "",
       timezone: config.timezone || ""
     });
-    sync.push("world-clock.logo.update", "put", { ...logo });
+    sync.push("world-clock.logo.update", "put", logoPayload());
   }
 
   function clearLogoClock() {
     Object.assign(logo, { enabled: false, cityName: "", timezone: "" });
-    sync.push("world-clock.logo.update", "put", { ...logo });
+    sync.push("world-clock.logo.update", "put", logoPayload());
   }
 
   return { logo, setLogoClock, clearLogoClock };

--- a/resources/js/composables/useLogoPreference.js
+++ b/resources/js/composables/useLogoPreference.js
@@ -2,8 +2,10 @@ import { useWorldClockSync } from "@/composables/useWorldClockSync";
 
 // Lets users replace the top-left nav logo with a configured clock. The choice
 // is now part of the shared server state (see useWorldClockSync), so the same
-// logo clock shows for everyone. `logo` is the live shared object — mutated in
-// place so the nav logo updates app-wide. Public API is unchanged.
+// logo clock shows for everyone. The logo only records WHICH city is pinned —
+// its appearance (face/hands/numerals) is the shared global appearance, so the
+// nav logo always matches the clocks on the World Clock page. `logo` is the
+// live shared object, mutated in place so the nav logo updates app-wide.
 
 export function useLogoPreference() {
   const sync = useWorldClockSync();
@@ -13,23 +15,13 @@ export function useLogoPreference() {
     Object.assign(logo, {
       enabled: true,
       cityName: config.cityName || "",
-      timezone: config.timezone || "",
-      facePreset: config.facePreset || "classic",
-      handPreset: config.handPreset || "classic",
-      numerals: config.numerals || "none"
+      timezone: config.timezone || ""
     });
     sync.push("world-clock.logo.update", "put", { ...logo });
   }
 
   function clearLogoClock() {
-    Object.assign(logo, {
-      enabled: false,
-      cityName: "",
-      timezone: "",
-      facePreset: "theme",
-      handPreset: "classic",
-      numerals: "none"
-    });
+    Object.assign(logo, { enabled: false, cityName: "", timezone: "" });
     sync.push("world-clock.logo.update", "put", { ...logo });
   }
 

--- a/resources/js/composables/useLogoPreference.test.js
+++ b/resources/js/composables/useLogoPreference.test.js
@@ -18,13 +18,7 @@ describe("composables/useLogoPreference", () => {
 
   it("setLogoClock enables the chosen clock and pushes to the server", () => {
     const { logo, setLogoClock } = useLogoPreference();
-    setLogoClock({
-      cityName: "Tokyo",
-      timezone: "Asia/Tokyo",
-      facePreset: "night",
-      handPreset: "ornate",
-      numerals: "roman"
-    });
+    setLogoClock({ cityName: "Tokyo", timezone: "Asia/Tokyo" });
 
     expect(logo.enabled).toBe(true);
     expect(logo.timezone).toBe("Asia/Tokyo");
@@ -34,7 +28,11 @@ describe("composables/useLogoPreference", () => {
       expect.objectContaining({
         url: "/api/world-clock/logo",
         method: "put",
-        data: expect.objectContaining({ enabled: true, cityName: "Tokyo" })
+        data: {
+          enabled: true,
+          cityName: "Tokyo",
+          timezone: "Asia/Tokyo"
+        }
       })
     );
   });
@@ -52,7 +50,7 @@ describe("composables/useLogoPreference", () => {
       expect.objectContaining({
         url: "/api/world-clock/logo",
         method: "put",
-        data: expect.objectContaining({ enabled: false })
+        data: { enabled: false, cityName: "", timezone: "" }
       })
     );
   });

--- a/resources/js/composables/useLogoPreference.test.js
+++ b/resources/js/composables/useLogoPreference.test.js
@@ -1,22 +1,22 @@
 import { useLogoPreference } from "@/composables/useLogoPreference";
-import { beforeEach, describe, expect, it } from "vitest";
-import { nextTick } from "vue";
-
-const STORAGE_KEY = "shudderfly.worldClock.logo";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("composables/useLogoPreference", () => {
   beforeEach(() => {
-    const { clearLogoClock } = useLogoPreference();
-    clearLogoClock();
-    localStorage.clear();
+    window.Echo = {
+      socketId: () => "socket-123",
+      private: () => ({ listen: () => {} })
+    };
+    window.axios = {
+      request: vi.fn().mockResolvedValue({
+        data: { server_now: new Date().toISOString() }
+      })
+    };
+    useLogoPreference().clearLogoClock();
+    window.axios.request.mockClear();
   });
 
-  it("starts disabled by default", () => {
-    const { logo } = useLogoPreference();
-    expect(logo.enabled).toBe(false);
-  });
-
-  it("setLogoClock enables and stores the chosen clock", async () => {
+  it("setLogoClock enables the chosen clock and pushes to the server", () => {
     const { logo, setLogoClock } = useLogoPreference();
     setLogoClock({
       cityName: "Tokyo",
@@ -30,14 +30,16 @@ describe("composables/useLogoPreference", () => {
     expect(logo.timezone).toBe("Asia/Tokyo");
     expect(logo.cityName).toBe("Tokyo");
 
-    await nextTick();
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
-    expect(stored.enabled).toBe(true);
-    expect(stored.timezone).toBe("Asia/Tokyo");
-    expect(stored.facePreset).toBe("night");
+    expect(window.axios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/world-clock/logo",
+        method: "put",
+        data: expect.objectContaining({ enabled: true, cityName: "Tokyo" })
+      })
+    );
   });
 
-  it("clearLogoClock resets to the default logo", async () => {
+  it("clearLogoClock resets to the default logo and pushes", () => {
     const { logo, setLogoClock, clearLogoClock } = useLogoPreference();
     setLogoClock({ cityName: "Paris", timezone: "Europe/Paris" });
     expect(logo.enabled).toBe(true);
@@ -46,8 +48,12 @@ describe("composables/useLogoPreference", () => {
     expect(logo.enabled).toBe(false);
     expect(logo.timezone).toBe("");
 
-    await nextTick();
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
-    expect(stored.enabled).toBe(false);
+    expect(window.axios.request).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        url: "/api/world-clock/logo",
+        method: "put",
+        data: expect.objectContaining({ enabled: false })
+      })
+    );
   });
 });

--- a/resources/js/composables/useWorldClockPreferences.js
+++ b/resources/js/composables/useWorldClockPreferences.js
@@ -24,8 +24,12 @@ export function useWorldClockPreferences(maxCities = 6) {
       // Skip saves triggered by an incoming server payload — otherwise the
       // remote update would echo straight back as a new write.
       if (sync.isApplyingRemote()) return;
+      const scheduledEpoch = sync.remoteEpoch();
       clearTimeout(timer);
       timer = setTimeout(() => {
+        // A remote update arrived while we were waiting — it supersedes this
+        // local edit, so don't write the now-stale value back.
+        if (sync.remoteEpoch() !== scheduledEpoch) return;
         sync.push("world-clock.settings.update", "put", {
           cities: prefs.cities,
           face_preset: prefs.facePreset,

--- a/resources/js/composables/useWorldClockPreferences.js
+++ b/resources/js/composables/useWorldClockPreferences.js
@@ -27,7 +27,9 @@ export function useWorldClockPreferences(maxCities = 6) {
       clearTimeout(timer);
       timer = setTimeout(() => {
         sync.push("world-clock.settings.update", "put", {
-          cities: prefs.cities,
+          // Cap defensively so a stale, over-limit city list can't fail
+          // validation and silently drop the appearance change.
+          cities: prefs.cities.slice(0, maxCities),
           face_preset: prefs.facePreset,
           hand_preset: prefs.handPreset,
           numerals: prefs.numerals,

--- a/resources/js/composables/useWorldClockPreferences.js
+++ b/resources/js/composables/useWorldClockPreferences.js
@@ -1,65 +1,38 @@
-import { reactive, toRaw, watch } from "vue";
+import { watch } from "vue";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
 
-const STORAGE_KEY = "shudderfly.worldClock";
+// Clock cities + appearance presets, backed by the shared server state (see
+// useWorldClockSync). The reactive `prefs` object IS the global state, so any
+// change a user makes is debounced and pushed to the server, then broadcast to
+// everyone. Public API is unchanged from the old localStorage version.
 
-const DEFAULTS = {
-  facePreset: "theme",
-  handPreset: "classic",
-  numerals: "arabic",
-  secondHandMode: "smooth",
-  cities: []
-};
-
-function sanitize(raw) {
-  const clean = {};
-  if (typeof raw.facePreset === "string") clean.facePreset = raw.facePreset;
-  if (typeof raw.handPreset === "string") clean.handPreset = raw.handPreset;
-  if (typeof raw.numerals === "string") clean.numerals = raw.numerals;
-  if (typeof raw.secondHandMode === "string")
-    clean.secondHandMode = raw.secondHandMode;
-  if (Array.isArray(raw.cities)) {
-    clean.cities = raw.cities
-      .filter((c) => c && c.timezone && c.name)
-      .map((c) => ({
-        name: String(c.name),
-        timezone: String(c.timezone),
-        country: c.country ? String(c.country) : ""
-      }));
-  }
-  return clean;
-}
-
-export function useWorldClockPreferences(defaultCities = [], maxCities = 6) {
-  const prefs = reactive({ ...DEFAULTS });
-
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) Object.assign(prefs, sanitize(JSON.parse(stored)));
-  } catch (e) {
-    console.error("Error loading world clock preferences:", e);
-  }
-
-  prefs.cities = prefs.cities.slice(0, maxCities);
-
-  if (!prefs.cities.length) {
-    prefs.cities = defaultCities.slice(0, maxCities).map((c) => ({
-      name: c.name,
-      timezone: c.timezone,
-      country: c.country || ""
-    }));
-  }
+// Cities are seeded server-side now, so this no longer takes default cities.
+export function useWorldClockPreferences(maxCities = 6) {
+  const sync = useWorldClockSync();
+  const prefs = sync.state;
 
   let timer = null;
   watch(
-    prefs,
+    () => [
+      prefs.cities,
+      prefs.facePreset,
+      prefs.handPreset,
+      prefs.numerals,
+      prefs.secondHandMode
+    ],
     () => {
+      // Skip saves triggered by an incoming server payload — otherwise the
+      // remote update would echo straight back as a new write.
+      if (sync.isApplyingRemote()) return;
       clearTimeout(timer);
       timer = setTimeout(() => {
-        try {
-          localStorage.setItem(STORAGE_KEY, JSON.stringify(toRaw(prefs)));
-        } catch (e) {
-          console.error("Error saving world clock preferences:", e);
-        }
+        sync.push("world-clock.settings.update", "put", {
+          cities: prefs.cities,
+          face_preset: prefs.facePreset,
+          hand_preset: prefs.handPreset,
+          numerals: prefs.numerals,
+          second_hand_mode: prefs.secondHandMode
+        });
       }, 300);
     },
     { deep: true }

--- a/resources/js/composables/useWorldClockPreferences.js
+++ b/resources/js/composables/useWorldClockPreferences.js
@@ -22,14 +22,10 @@ export function useWorldClockPreferences(maxCities = 6) {
     ],
     () => {
       // Skip saves triggered by an incoming server payload — otherwise the
-      // remote update would echo straight back as a new write.
+      // remote update would echo straight back as a new write (feedback loop).
       if (sync.isApplyingRemote()) return;
-      const scheduledEpoch = sync.remoteEpoch();
       clearTimeout(timer);
       timer = setTimeout(() => {
-        // A remote update arrived while we were waiting — it supersedes this
-        // local edit, so don't write the now-stale value back.
-        if (sync.remoteEpoch() !== scheduledEpoch) return;
         sync.push("world-clock.settings.update", "put", {
           cities: prefs.cities,
           face_preset: prefs.facePreset,

--- a/resources/js/composables/useWorldClockPreferences.test.js
+++ b/resources/js/composables/useWorldClockPreferences.test.js
@@ -3,9 +3,8 @@ import { useWorldClockSync } from "@/composables/useWorldClockSync";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 
-// One shared watcher for the file, mirroring the singleton in the app.
-const sync = useWorldClockSync();
-const { prefs } = useWorldClockPreferences(6);
+let sync;
+let prefs;
 
 describe("composables/useWorldClockPreferences", () => {
   beforeEach(() => {
@@ -19,6 +18,12 @@ describe("composables/useWorldClockPreferences", () => {
       })
     };
     vi.useFakeTimers();
+
+    // Initialize after stubs are in place so setupEcho() doesn't schedule retries.
+    if (!sync) {
+      sync = useWorldClockSync();
+      ({ prefs } = useWorldClockPreferences(6));
+    }
   });
 
   afterEach(() => {

--- a/resources/js/composables/useWorldClockPreferences.test.js
+++ b/resources/js/composables/useWorldClockPreferences.test.js
@@ -37,17 +37,17 @@ describe("composables/useWorldClockPreferences", () => {
     );
   });
 
-  it("does not write a stale value when a remote update supersedes the edit", async () => {
+  it("does not re-save a change that arrived from a remote broadcast", async () => {
     window.axios.request.mockClear();
-    prefs.facePreset = "ornate";
-    await nextTick();
-    // A genuine remote change arrives before the debounce fires.
+    // A live update from another client must update local state without echoing
+    // back as a new save (which would cause a feedback loop).
     sync.applyRemote({
       face_preset: "minimal",
       server_now: new Date().toISOString()
     });
     await nextTick();
     vi.advanceTimersByTime(300);
+    expect(prefs.facePreset).toBe("minimal");
     expect(window.axios.request).not.toHaveBeenCalled();
   });
 });

--- a/resources/js/composables/useWorldClockPreferences.test.js
+++ b/resources/js/composables/useWorldClockPreferences.test.js
@@ -1,0 +1,53 @@
+import { useWorldClockPreferences } from "@/composables/useWorldClockPreferences";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+// One shared watcher for the file, mirroring the singleton in the app.
+const sync = useWorldClockSync();
+const { prefs } = useWorldClockPreferences(6);
+
+describe("composables/useWorldClockPreferences", () => {
+  beforeEach(() => {
+    window.Echo = {
+      socketId: () => "socket-123",
+      private: () => ({ listen: () => {} })
+    };
+    window.axios = {
+      request: vi.fn().mockResolvedValue({
+        data: { server_now: new Date().toISOString() }
+      })
+    };
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("saves an appearance change after the debounce", async () => {
+    prefs.facePreset = "night";
+    await nextTick();
+    vi.advanceTimersByTime(300);
+    expect(window.axios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/world-clock/settings",
+        method: "put"
+      })
+    );
+  });
+
+  it("does not write a stale value when a remote update supersedes the edit", async () => {
+    window.axios.request.mockClear();
+    prefs.facePreset = "ornate";
+    await nextTick();
+    // A genuine remote change arrives before the debounce fires.
+    sync.applyRemote({
+      face_preset: "minimal",
+      server_now: new Date().toISOString()
+    });
+    await nextTick();
+    vi.advanceTimersByTime(300);
+    expect(window.axios.request).not.toHaveBeenCalled();
+  });
+});

--- a/resources/js/composables/useWorldClockSync.js
+++ b/resources/js/composables/useWorldClockSync.js
@@ -36,13 +36,12 @@ const serverOffsetMs = ref(0);
 let applyingRemote = false;
 let echoReady = false;
 let echoAttempts = 0;
-// Bumped on every full remote apply (hydrate / Echo broadcast). A pending
-// debounced local save captures the epoch when scheduled and bails if it has
-// changed, so a genuine remote update can't be clobbered by a stale save.
-let remoteEpochValue = 0;
+// Seeded from server props exactly once per page load. Re-seeding on later prop
+// refreshes is avoided so a background update can never revert an in-flight
+// local edit; live updates from other clients arrive via the Echo broadcast.
+let hydrated = false;
 
 const isApplyingRemote = () => applyingRemote;
-const remoteEpoch = () => remoteEpochValue;
 
 function assignPayload(payload) {
   if (!payload || typeof payload !== "object") return;
@@ -68,10 +67,8 @@ function assignPayload(payload) {
 
 // Apply full state that originated from the server (initial hydration or a live
 // broadcast from another client) without triggering the local save watchers.
-// Bumps the remote epoch so any in-flight local save is superseded.
 function applyRemote(payload) {
   applyingRemote = true;
-  remoteEpochValue += 1;
   assignPayload(payload);
   nextTick(() => {
     applyingRemote = false;
@@ -91,9 +88,12 @@ function reconcileTimer(payload) {
   }
 }
 
-// Idempotent: called from both the layout (app-wide, for the nav logo + timer)
-// and the World Clock page. Each Inertia navigation carries fresh server props.
+// Seed the shared state from server props. Runs only the first time (per page
+// load) — both the layout and the World Clock page call it, and later prop
+// refreshes must not overwrite local edits or live broadcast state.
 function hydrate(initial) {
+  if (hydrated) return;
+  hydrated = true;
   applyRemote(initial);
 }
 
@@ -151,7 +151,6 @@ export function useWorldClockSync() {
     applyRemote,
     reconcileTimer,
     push,
-    isApplyingRemote,
-    remoteEpoch
+    isApplyingRemote
   };
 }

--- a/resources/js/composables/useWorldClockSync.js
+++ b/resources/js/composables/useWorldClockSync.js
@@ -10,10 +10,7 @@ import { nextTick, reactive, ref } from "vue";
 const DEFAULT_LOGO = {
   enabled: false,
   cityName: "",
-  timezone: "",
-  facePreset: "theme",
-  handPreset: "classic",
-  numerals: "none"
+  timezone: ""
 };
 
 const state = reactive({

--- a/resources/js/composables/useWorldClockSync.js
+++ b/resources/js/composables/useWorldClockSync.js
@@ -1,0 +1,125 @@
+/* global route */
+import { nextTick, reactive, ref } from "vue";
+
+// The single source of truth for the World Clock, shared by every user. State
+// is a module-level singleton: it is hydrated from server props on load, pushed
+// to the server (debounced by callers) on local change, and reconciled live via
+// a Pusher/Echo broadcast. Replaces the old per-user localStorage storage so the
+// chosen cities, appearance, timer, and logo clock are identical for everyone.
+
+const DEFAULT_LOGO = {
+  enabled: false,
+  cityName: "",
+  timezone: "",
+  facePreset: "theme",
+  handPreset: "classic",
+  numerals: "none"
+};
+
+const state = reactive({
+  cities: [],
+  facePreset: "theme",
+  handPreset: "classic",
+  numerals: "arabic",
+  secondHandMode: "smooth",
+  logo: { ...DEFAULT_LOGO },
+  timerEndsAt: null
+});
+
+// Difference between the server clock and this client's clock, recomputed from
+// every payload's `server_now`. The timer countdown applies this offset so all
+// clients agree on how much time is left regardless of local clock skew.
+const serverOffsetMs = ref(0);
+
+// True while we are applying a server payload, so the local save watchers can
+// skip — otherwise an incoming change would echo straight back as a new save.
+let applyingRemote = false;
+let echoReady = false;
+let echoAttempts = 0;
+
+const isApplyingRemote = () => applyingRemote;
+
+function assignPayload(payload) {
+  if (!payload || typeof payload !== "object") return;
+  if (Array.isArray(payload.cities)) state.cities = payload.cities;
+  if (typeof payload.face_preset === "string")
+    state.facePreset = payload.face_preset;
+  if (typeof payload.hand_preset === "string")
+    state.handPreset = payload.hand_preset;
+  if (typeof payload.numerals === "string") state.numerals = payload.numerals;
+  if (typeof payload.second_hand_mode === "string")
+    state.secondHandMode = payload.second_hand_mode;
+  if (payload.logo && typeof payload.logo === "object") {
+    // Mutate in place so references held by components (the nav logo) stay live.
+    Object.assign(state.logo, DEFAULT_LOGO, payload.logo);
+  }
+  state.timerEndsAt = payload.timer_ends_at || null;
+
+  if (payload.server_now) {
+    const parsed = Date.parse(payload.server_now);
+    if (!Number.isNaN(parsed)) serverOffsetMs.value = parsed - Date.now();
+  }
+}
+
+// Apply state that originated from the server (initial hydration or a broadcast)
+// without triggering the local save watchers.
+function applyRemote(payload) {
+  applyingRemote = true;
+  assignPayload(payload);
+  nextTick(() => {
+    applyingRemote = false;
+  });
+}
+
+// Idempotent: called from both the layout (app-wide, for the nav logo + timer)
+// and the World Clock page. Each Inertia navigation carries fresh server props.
+function hydrate(initial) {
+  applyRemote(initial);
+}
+
+// Persist a change to the server and reconcile from the response (so it works
+// even when websockets are unavailable). The X-Socket-ID header lets the server
+// exclude this client from the broadcast, preventing a feedback loop.
+async function push(routeName, method, body = {}) {
+  try {
+    const headers = {};
+    const socketId = window.Echo?.socketId?.();
+    if (socketId) headers["X-Socket-ID"] = socketId;
+
+    const response = await window.axios.request({
+      url: route(routeName),
+      method,
+      data: body,
+      headers
+    });
+    applyRemote(response.data);
+  } catch (e) {
+    console.error(`Error syncing world clock (${routeName}):`, e);
+  }
+}
+
+// Subscribe once to the broadcast channel. Mirrors the retry/guard pattern used
+// for the messages channel; degrades silently when Echo/Pusher is unavailable.
+function setupEcho() {
+  if (echoReady) return;
+  if (!window.Echo) {
+    // Give up after ~10s: Pusher may be unconfigured, in which case the app
+    // still works via server reconcile + fresh props on each navigation.
+    if (echoAttempts++ >= 20) return;
+    setTimeout(setupEcho, 500);
+    return;
+  }
+  try {
+    window.Echo.private("world-clock").listen(".WorldClockUpdated", (payload) =>
+      applyRemote(payload)
+    );
+    echoReady = true;
+  } catch (e) {
+    console.error("Error setting up world clock Echo listener:", e);
+  }
+}
+
+export function useWorldClockSync() {
+  setupEcho();
+  return { state, serverOffsetMs, hydrate, applyRemote, push, isApplyingRemote };
+}

--- a/resources/js/composables/useWorldClockSync.js
+++ b/resources/js/composables/useWorldClockSync.js
@@ -36,8 +36,13 @@ const serverOffsetMs = ref(0);
 let applyingRemote = false;
 let echoReady = false;
 let echoAttempts = 0;
+// Bumped on every full remote apply (hydrate / Echo broadcast). A pending
+// debounced local save captures the epoch when scheduled and bails if it has
+// changed, so a genuine remote update can't be clobbered by a stale save.
+let remoteEpochValue = 0;
 
 const isApplyingRemote = () => applyingRemote;
+const remoteEpoch = () => remoteEpochValue;
 
 function assignPayload(payload) {
   if (!payload || typeof payload !== "object") return;
@@ -61,14 +66,29 @@ function assignPayload(payload) {
   }
 }
 
-// Apply state that originated from the server (initial hydration or a broadcast)
-// without triggering the local save watchers.
+// Apply full state that originated from the server (initial hydration or a live
+// broadcast from another client) without triggering the local save watchers.
+// Bumps the remote epoch so any in-flight local save is superseded.
 function applyRemote(payload) {
   applyingRemote = true;
+  remoteEpochValue += 1;
   assignPayload(payload);
   nextTick(() => {
     applyingRemote = false;
   });
+}
+
+// Apply only the timer fields from a server response. Used by the originating
+// client after starting/stopping a timer to pick up the authoritative absolute
+// end time + clock offset, WITHOUT touching cities/appearance/logo (which would
+// clobber any local edit that hasn't been saved yet).
+function reconcileTimer(payload) {
+  if (!payload || typeof payload !== "object") return;
+  state.timerEndsAt = payload.timer_ends_at || null;
+  if (payload.server_now) {
+    const parsed = Date.parse(payload.server_now);
+    if (!Number.isNaN(parsed)) serverOffsetMs.value = parsed - Date.now();
+  }
 }
 
 // Idempotent: called from both the layout (app-wide, for the nav logo + timer)
@@ -77,9 +97,11 @@ function hydrate(initial) {
   applyRemote(initial);
 }
 
-// Persist a change to the server and reconcile from the response (so it works
-// even when websockets are unavailable). The X-Socket-ID header lets the server
-// exclude this client from the broadcast, preventing a feedback loop.
+// Persist a change to the server and return the fresh state. The originating
+// client's local state is already authoritative, so we deliberately do NOT
+// re-apply the full response here — that would overwrite fields the user is
+// still editing. Other clients receive the change via the Echo broadcast; the
+// X-Socket-ID header excludes this client from it, preventing a feedback loop.
 async function push(routeName, method, body = {}) {
   try {
     const headers = {};
@@ -92,9 +114,10 @@ async function push(routeName, method, body = {}) {
       data: body,
       headers
     });
-    applyRemote(response.data);
+    return response.data;
   } catch (e) {
     console.error(`Error syncing world clock (${routeName}):`, e);
+    return null;
   }
 }
 
@@ -121,5 +144,14 @@ function setupEcho() {
 
 export function useWorldClockSync() {
   setupEcho();
-  return { state, serverOffsetMs, hydrate, applyRemote, push, isApplyingRemote };
+  return {
+    state,
+    serverOffsetMs,
+    hydrate,
+    applyRemote,
+    reconcileTimer,
+    push,
+    isApplyingRemote,
+    remoteEpoch
+  };
 }

--- a/resources/js/composables/useWorldClockSync.test.js
+++ b/resources/js/composables/useWorldClockSync.test.js
@@ -72,11 +72,4 @@ describe("useWorldClockSync", () => {
     expect(data.face_preset).toBe("minimal");
     expect(sync.state.facePreset).toBe("classic");
   });
-
-  it("a remote apply bumps the epoch so stale local saves can detect it", () => {
-    const sync = useWorldClockSync();
-    const before = sync.remoteEpoch();
-    sync.applyRemote({ face_preset: "night", server_now: new Date().toISOString() });
-    expect(sync.remoteEpoch()).toBe(before + 1);
-  });
 });

--- a/resources/js/composables/useWorldClockSync.test.js
+++ b/resources/js/composables/useWorldClockSync.test.js
@@ -45,16 +45,20 @@ describe("useWorldClockSync", () => {
     expect(sync.isApplyingRemote()).toBe(false);
   });
 
-  it("push sends the socket id header and reconciles from the response", async () => {
-    const responseNow = new Date().toISOString();
+  it("push sends the socket id header and returns the response without clobbering local state", async () => {
     window.axios = {
       request: vi.fn().mockResolvedValue({
-        data: { face_preset: "minimal", server_now: responseNow }
+        data: { face_preset: "minimal", server_now: new Date().toISOString() }
       })
     };
 
     const sync = useWorldClockSync();
-    await sync.push("world-clock.settings.update", "put", { face_preset: "minimal" });
+    // Local edit the user is in the middle of making.
+    sync.state.facePreset = "classic";
+
+    const data = await sync.push("world-clock.settings.update", "put", {
+      face_preset: "classic"
+    });
 
     expect(window.axios.request).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -63,6 +67,16 @@ describe("useWorldClockSync", () => {
         headers: expect.objectContaining({ "X-Socket-ID": "socket-123" })
       })
     );
-    expect(sync.state.facePreset).toBe("minimal");
+    // push returns the server payload but must NOT overwrite local state — that
+    // would clobber an edit the user is still making.
+    expect(data.face_preset).toBe("minimal");
+    expect(sync.state.facePreset).toBe("classic");
+  });
+
+  it("a remote apply bumps the epoch so stale local saves can detect it", () => {
+    const sync = useWorldClockSync();
+    const before = sync.remoteEpoch();
+    sync.applyRemote({ face_preset: "night", server_now: new Date().toISOString() });
+    expect(sync.remoteEpoch()).toBe(before + 1);
   });
 });

--- a/resources/js/composables/useWorldClockSync.test.js
+++ b/resources/js/composables/useWorldClockSync.test.js
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { useWorldClockSync } from "@/composables/useWorldClockSync";
+
+// A minimal Echo stub so setupEcho() completes instead of polling forever.
+beforeEach(() => {
+  window.Echo = {
+    socketId: () => "socket-123",
+    private: () => ({ listen: () => {} })
+  };
+});
+
+describe("useWorldClockSync", () => {
+  it("applies a remote payload to state and computes the server offset", async () => {
+    const sync = useWorldClockSync();
+    const serverNow = new Date(Date.now() + 60000).toISOString(); // 1 min ahead
+
+    sync.applyRemote({
+      cities: [{ name: "Berlin", timezone: "Europe/Berlin", country: "Germany" }],
+      face_preset: "night",
+      hand_preset: "ornate",
+      numerals: "roman",
+      second_hand_mode: "tick",
+      logo: { enabled: true, cityName: "Berlin" },
+      timer_ends_at: null,
+      server_now: serverNow
+    });
+
+    expect(sync.state.cities[0].name).toBe("Berlin");
+    expect(sync.state.facePreset).toBe("night");
+    expect(sync.state.secondHandMode).toBe("tick");
+    expect(sync.state.logo.enabled).toBe(true);
+    // Server is ~60s ahead of the client.
+    expect(sync.serverOffsetMs.value).toBeGreaterThan(50000);
+    expect(sync.serverOffsetMs.value).toBeLessThan(70000);
+  });
+
+  it("flags applyingRemote during apply and clears it after a tick", async () => {
+    const sync = useWorldClockSync();
+
+    sync.applyRemote({ face_preset: "classic", server_now: new Date().toISOString() });
+    expect(sync.isApplyingRemote()).toBe(true);
+
+    await nextTick();
+    expect(sync.isApplyingRemote()).toBe(false);
+  });
+
+  it("push sends the socket id header and reconciles from the response", async () => {
+    const responseNow = new Date().toISOString();
+    window.axios = {
+      request: vi.fn().mockResolvedValue({
+        data: { face_preset: "minimal", server_now: responseNow }
+      })
+    };
+
+    const sync = useWorldClockSync();
+    await sync.push("world-clock.settings.update", "put", { face_preset: "minimal" });
+
+    expect(window.axios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/world-clock/settings",
+        method: "put",
+        headers: expect.objectContaining({ "X-Socket-ID": "socket-123" })
+      })
+    );
+    expect(sync.state.facePreset).toBe("minimal");
+  });
+});

--- a/resources/js/vitest.setup.js
+++ b/resources/js/vitest.setup.js
@@ -113,6 +113,10 @@ export const ROUTE_MAPPINGS = {
     "movie-cast.share": "/movie-cast/share",
     "world-clock.index": "/world-clock",
     "world-clock.cities.search": "/api/world-clock/cities/search",
+    "world-clock.settings.update": "/api/world-clock/settings",
+    "world-clock.logo.update": "/api/world-clock/logo",
+    "world-clock.timer.start": "/api/world-clock/timer",
+    "world-clock.timer.stop": "/api/world-clock/timer",
 };
 
 export const createRouteMock = () =>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\SiteSetting;
 use Illuminate\Support\Facades\Broadcast;
 
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
@@ -10,10 +11,14 @@ Broadcast::channel('collages', function ($user) {
     return true;
 });
 
+Broadcast::channel('world-clock', function ($user) {
+    return true;
+});
+
 Broadcast::channel('messages', function ($user) {
     // For private channels, Laravel automatically ensures $user is authenticated
     // Check if messaging is enabled
-    $setting = \App\Models\SiteSetting::where('key', 'messaging_enabled')->first();
+    $setting = SiteSetting::where('key', 'messaging_enabled')->first();
     $messagingEnabled = $setting && ($setting->getAttributes()['value'] ?? $setting->value) === '1';
 
     // Return user data if messaging is enabled and user is authenticated, false otherwise

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,6 +88,14 @@ Route::middleware('auth')->group(function () {
     Route::get('/world-clock', [WorldClockController::class, 'index'])->name('world-clock.index');
     Route::get('/api/world-clock/cities/search', [WorldClockController::class, 'searchCities'])
         ->name('world-clock.cities.search');
+    Route::put('/api/world-clock/settings', [WorldClockController::class, 'updateSettings'])
+        ->name('world-clock.settings.update');
+    Route::put('/api/world-clock/logo', [WorldClockController::class, 'updateLogo'])
+        ->name('world-clock.logo.update');
+    Route::post('/api/world-clock/timer', [WorldClockController::class, 'startTimer'])
+        ->name('world-clock.timer.start');
+    Route::delete('/api/world-clock/timer', [WorldClockController::class, 'stopTimer'])
+        ->name('world-clock.timer.stop');
 
     Route::post('/collage-page', [CollagePageController::class, 'store'])->name('collage-page.store');
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,13 +3,14 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
 
 trait CreatesApplication
 {
     /**
      * Creates the application.
      *
-     * @return \Illuminate\Foundation\Application
+     * @return Application
      */
     public function createApplication()
     {

--- a/tests/Feature/BooksTest.php
+++ b/tests/Feature/BooksTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Jobs\IncrementBookReadCount;
 use App\Models\Book;
 use App\Models\Category;
 use App\Models\Page;
@@ -172,11 +173,11 @@ class BooksTest extends TestCase
         Book::factory()->count(20)->create(['read_count' => 300]);
 
         // Run jobs directly for testing
-        (new \App\Jobs\IncrementBookReadCount($newBook, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementBookReadCount($twoWeekOldBook, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementBookReadCount($twoMonthOldBook, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementBookReadCount($sixMonthOldBook, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementBookReadCount($veryOldBook, 'test-fingerprint'))->handle();
+        (new IncrementBookReadCount($newBook, 'test-fingerprint'))->handle();
+        (new IncrementBookReadCount($twoWeekOldBook, 'test-fingerprint'))->handle();
+        (new IncrementBookReadCount($twoMonthOldBook, 'test-fingerprint'))->handle();
+        (new IncrementBookReadCount($sixMonthOldBook, 'test-fingerprint'))->handle();
+        (new IncrementBookReadCount($veryOldBook, 'test-fingerprint'))->handle();
 
         // Verify age-based multipliers
         $this->assertSame(3.0, $newBook->fresh()->read_count);
@@ -294,7 +295,7 @@ class BooksTest extends TestCase
         Page::factory()->for($book)->count(2)->state(['video_link' => 'https://youtube.com/watch?v=123'])->create(); // Video pages
 
         // Set youtube_enabled to false
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
 
         // Test book show page - should only show regular pages
         $this->get(route('books.show', $book))->assertInertia(
@@ -304,7 +305,7 @@ class BooksTest extends TestCase
         );
 
         // Enable YouTube
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '1']);
 
         // Test book show page again - should now show all pages
         $this->get(route('books.show', $book))->assertInertia(

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Jobs\IncrementPageReadCount;
 use App\Models\Book;
 use App\Models\Message;
 use App\Models\Page;
@@ -47,7 +48,7 @@ class PagesTest extends TestCase
         ); // Video pages
 
         // Set youtube_enabled to false
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
 
         // Test index page - should only show regular pages when YouTube is disabled
         $this->get(route('pictures.index'))->assertInertia(
@@ -64,7 +65,7 @@ class PagesTest extends TestCase
         );
 
         // Enable YouTube
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '1']);
 
         // Test index page again - should now show all pages
         $this->get(route('pictures.index'))->assertInertia(
@@ -90,7 +91,7 @@ class PagesTest extends TestCase
         $videoPage = Page::factory()->for($book)->state(['video_link' => 'https://youtube.com/watch?v=123'])->create();
 
         // Set youtube_enabled to false
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
 
         // Regular page should be accessible
         $this->get(route('pages.show', $regularPage))->assertStatus(200);
@@ -247,11 +248,11 @@ class PagesTest extends TestCase
         ); // >90 days: 1.0x
 
         // Run jobs directly for testing
-        (new \App\Jobs\IncrementPageReadCount($newPage, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementPageReadCount($monthOldPage, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementPageReadCount($threeMonthOldPage, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementPageReadCount($yearOldPage, 'test-fingerprint'))->handle();
-        (new \App\Jobs\IncrementPageReadCount($veryOldPage, 'test-fingerprint'))->handle();
+        (new IncrementPageReadCount($newPage, 'test-fingerprint'))->handle();
+        (new IncrementPageReadCount($monthOldPage, 'test-fingerprint'))->handle();
+        (new IncrementPageReadCount($threeMonthOldPage, 'test-fingerprint'))->handle();
+        (new IncrementPageReadCount($yearOldPage, 'test-fingerprint'))->handle();
+        (new IncrementPageReadCount($veryOldPage, 'test-fingerprint'))->handle();
 
         // Verify age-based behavior with new logic
         $this->assertSame(-1.0 + 3.0, $newPage->fresh()->read_count); // ≤7 days: initial 3.0x boost
@@ -1045,7 +1046,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(5)->create();
@@ -1063,7 +1064,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(3)->create();
@@ -1081,7 +1082,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(5)->create();
@@ -1099,7 +1100,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(3)->create(['read_count' => 100]);
@@ -1117,7 +1118,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(10)->create();
@@ -1135,7 +1136,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $yearAgo = now()->subYear();
         $book = Book::factory()->create();
@@ -1154,7 +1155,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->create(['content' => 'Test content with keyword']);
@@ -1172,7 +1173,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->create(['content' => 'Test content with keyword']);
@@ -1190,7 +1191,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(30)->create();
@@ -1209,7 +1210,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(20)->create();
@@ -1233,7 +1234,7 @@ class PagesTest extends TestCase
         Song::factory()->count(5)->create();
 
         // Start with music enabled
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
 
         $response1 = $this->get(route('pictures.index'));
         $response1->assertInertia(
@@ -1241,7 +1242,7 @@ class PagesTest extends TestCase
         );
 
         // Disable music
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         $response2 = $this->get(route('pictures.index'));
         $response2->assertInertia(
@@ -1249,7 +1250,7 @@ class PagesTest extends TestCase
         );
 
         // Re-enable music
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
 
         $response3 = $this->get(route('pictures.index'));
         $response3->assertInertia(
@@ -1261,8 +1262,8 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '0']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(2)->create();
@@ -1281,8 +1282,8 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
-        \App\Models\SiteSetting::where('key', 'youtube_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'youtube_enabled')->update(['value' => '1']);
 
         $book = Book::factory()->create();
         Page::factory()->for($book)->count(2)->create();
@@ -1301,7 +1302,7 @@ class PagesTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        \App\Models\SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'music_enabled')->update(['value' => '0']);
 
         // Create only songs, no pages
         Song::factory()->count(5)->create();

--- a/tests/Feature/SoundsTest.php
+++ b/tests/Feature/SoundsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Jobs\StoreSoundAudio;
+use App\Models\SiteSetting;
 use App\Models\Sound;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -23,7 +24,7 @@ class SoundsTest extends TestCase
 
         Storage::fake('s3');
 
-        \App\Models\SiteSetting::where('key', 'sounds_enabled')->update(['value' => '1']);
+        SiteSetting::where('key', 'sounds_enabled')->update(['value' => '1']);
     }
 
     // ── Access / gating ────────────────────────────────────────────────────────
@@ -36,7 +37,7 @@ class SoundsTest extends TestCase
 
     public function test_sounds_page_returns_404_when_disabled(): void
     {
-        \App\Models\SiteSetting::where('key', 'sounds_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'sounds_enabled')->update(['value' => '0']);
 
         $user = User::factory()->create();
         $this->actingAs($user);
@@ -275,7 +276,7 @@ class SoundsTest extends TestCase
 
     public function test_store_returns_404_when_sounds_disabled(): void
     {
-        \App\Models\SiteSetting::where('key', 'sounds_enabled')->update(['value' => '0']);
+        SiteSetting::where('key', 'sounds_enabled')->update(['value' => '0']);
 
         $user = User::factory()->create();
         $user->givePermissionTo('edit pages');
@@ -396,10 +397,10 @@ class SoundsTest extends TestCase
     public function test_sounds_enabled_setting_exists_in_database(): void
     {
         $this->assertTrue(
-            \App\Models\SiteSetting::where('key', 'sounds_enabled')->exists()
+            SiteSetting::where('key', 'sounds_enabled')->exists()
         );
 
-        $setting = \App\Models\SiteSetting::where('key', 'sounds_enabled')->first();
+        $setting = SiteSetting::where('key', 'sounds_enabled')->first();
         $this->assertEquals('boolean', $setting->type);
     }
 

--- a/tests/Feature/WorldClockTest.php
+++ b/tests/Feature/WorldClockTest.php
@@ -46,7 +46,22 @@ class WorldClockTest extends TestCase
 
         $this->assertNotEmpty($setting->cities);
         $this->assertSame('America/New_York', $setting->cities[0]['timezone']);
+        $this->assertLessThanOrEqual(config('world_clock.max_cities'), count($setting->cities));
         $this->assertSame(1, WorldClockSetting::count());
+    }
+
+    public function test_instance_heals_city_list_that_exceeds_the_limit(): void
+    {
+        $max = config('world_clock.max_cities');
+        $cities = [];
+        for ($i = 0; $i < $max + 4; $i++) {
+            $cities[] = ['name' => "City {$i}", 'timezone' => 'UTC', 'country' => ''];
+        }
+        WorldClockSetting::create(['cities' => $cities]);
+
+        // Reloading the singleton trims the over-limit list so settings saves
+        // (which include the full city list) pass validation.
+        $this->assertCount($max, WorldClockSetting::instance()->cities);
     }
 
     public function test_update_settings_persists_and_broadcasts(): void

--- a/tests/Feature/WorldClockTest.php
+++ b/tests/Feature/WorldClockTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Events\WorldClockUpdated;
 use App\Models\User;
+use App\Models\WorldClockSetting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
@@ -28,7 +31,117 @@ class WorldClockTest extends TestCase
                 ->where('maxCities', 6)
                 ->has('defaultCities')
                 ->where('defaultCities.0.timezone', 'America/New_York')
+                ->has('worldClock', fn (Assert $wc) => $wc
+                    ->has('cities')
+                    ->has('face_preset')
+                    ->has('timer_ends_at')
+                    ->has('server_now')
+                    ->etc())
         );
+    }
+
+    public function test_instance_seeds_default_cities(): void
+    {
+        $setting = WorldClockSetting::instance();
+
+        $this->assertNotEmpty($setting->cities);
+        $this->assertSame('America/New_York', $setting->cities[0]['timezone']);
+        $this->assertSame(1, WorldClockSetting::count());
+    }
+
+    public function test_update_settings_persists_and_broadcasts(): void
+    {
+        Event::fake([WorldClockUpdated::class]);
+        $this->actingAs(User::factory()->create());
+
+        $this->putJson(route('world-clock.settings.update'), [
+            'cities' => [
+                ['name' => 'Berlin', 'timezone' => 'Europe/Berlin', 'country' => 'Germany'],
+            ],
+            'face_preset' => 'night',
+            'hand_preset' => 'ornate',
+            'numerals' => 'roman',
+            'second_hand_mode' => 'tick',
+        ])->assertOk()->assertJsonPath('face_preset', 'night');
+
+        $setting = WorldClockSetting::instance();
+        $this->assertSame('night', $setting->face_preset);
+        $this->assertSame('Berlin', $setting->cities[0]['name']);
+        $this->assertSame(1, WorldClockSetting::count());
+
+        Event::assertDispatched(WorldClockUpdated::class);
+    }
+
+    public function test_update_settings_rejects_too_many_cities(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $cities = [];
+        for ($i = 0; $i < config('world_clock.max_cities') + 1; $i++) {
+            $cities[] = ['name' => "City {$i}", 'timezone' => 'UTC', 'country' => ''];
+        }
+
+        $this->putJson(route('world-clock.settings.update'), [
+            'cities' => $cities,
+            'face_preset' => 'theme',
+            'hand_preset' => 'classic',
+            'numerals' => 'arabic',
+            'second_hand_mode' => 'smooth',
+        ])->assertStatus(422);
+    }
+
+    public function test_guest_cannot_update_settings(): void
+    {
+        $this->putJson(route('world-clock.settings.update'), [
+            'cities' => [],
+            'face_preset' => 'theme',
+            'hand_preset' => 'classic',
+            'numerals' => 'arabic',
+            'second_hand_mode' => 'smooth',
+        ])->assertUnauthorized();
+    }
+
+    public function test_update_logo_persists(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->putJson(route('world-clock.logo.update'), [
+            'enabled' => true,
+            'cityName' => 'Tokyo',
+            'timezone' => 'Asia/Tokyo',
+            'facePreset' => 'minimal',
+            'handPreset' => 'skeleton',
+            'numerals' => 'none',
+        ])->assertOk()->assertJsonPath('logo.enabled', true);
+
+        $this->assertSame('Tokyo', WorldClockSetting::instance()->logo['cityName']);
+    }
+
+    public function test_start_and_stop_timer(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->postJson(route('world-clock.timer.start'), ['seconds' => 600])
+            ->assertOk()
+            ->assertJsonPath('timer_ends_at', fn ($v) => $v !== null);
+
+        $endsAt = WorldClockSetting::instance()->timer_ends_at;
+        $this->assertNotNull($endsAt);
+        $this->assertEqualsWithDelta(600, now()->diffInSeconds($endsAt, false), 5);
+
+        $this->deleteJson(route('world-clock.timer.stop'))
+            ->assertOk()
+            ->assertJsonPath('timer_ends_at', null);
+
+        $this->assertNull(WorldClockSetting::instance()->timer_ends_at);
+    }
+
+    public function test_start_timer_validates_seconds(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->postJson(route('world-clock.timer.start'), ['seconds' => 0])
+            ->assertStatus(422);
     }
 
     public function test_city_search_requires_query(): void

--- a/tests/Feature/WorldClockTest.php
+++ b/tests/Feature/WorldClockTest.php
@@ -116,20 +116,29 @@ class WorldClockTest extends TestCase
         ])->assertUnauthorized();
     }
 
-    public function test_update_logo_persists(): void
+    public function test_update_logo_persists_pinned_city_only(): void
     {
         $this->actingAs(User::factory()->create());
+
+        WorldClockSetting::instance()->update([
+            'face_preset' => 'night',
+            'hand_preset' => 'ornate',
+            'numerals' => 'roman',
+        ]);
 
         $this->putJson(route('world-clock.logo.update'), [
             'enabled' => true,
             'cityName' => 'Tokyo',
             'timezone' => 'Asia/Tokyo',
-            'facePreset' => 'minimal',
-            'handPreset' => 'skeleton',
-            'numerals' => 'none',
         ])->assertOk()->assertJsonPath('logo.enabled', true);
 
-        $this->assertSame('Tokyo', WorldClockSetting::instance()->logo['cityName']);
+        $logo = WorldClockSetting::instance()->logo;
+        $this->assertSame('Tokyo', $logo['cityName']);
+        $this->assertSame('Asia/Tokyo', $logo['timezone']);
+        $this->assertTrue($logo['enabled']);
+        $this->assertArrayNotHasKey('facePreset', $logo);
+        $this->assertArrayNotHasKey('handPreset', $logo);
+        $this->assertArrayNotHasKey('numerals', $logo);
     }
 
     public function test_start_and_stop_timer(): void

--- a/tests/Unit/CommentReactionTest.php
+++ b/tests/Unit/CommentReactionTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit;
 use App\Models\CommentReaction;
 use App\Models\MessageComment;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -75,8 +77,8 @@ class CommentReactionTest extends TestCase
     {
         $reaction = CommentReaction::factory()->create();
 
-        $this->assertInstanceOf(\Carbon\Carbon::class, $reaction->created_at);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $reaction->updated_at);
+        $this->assertInstanceOf(Carbon::class, $reaction->created_at);
+        $this->assertInstanceOf(Carbon::class, $reaction->updated_at);
     }
 
     public function test_unique_constraint_exists_on_comment_and_user(): void
@@ -93,7 +95,7 @@ class CommentReactionTest extends TestCase
 
         // Verify we can't create a duplicate reaction directly
         // (The application handles this by updating, but the constraint exists)
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
 
         CommentReaction::create([
             'comment_id' => $comment->id,

--- a/tests/Unit/MessageCommentTest.php
+++ b/tests/Unit/MessageCommentTest.php
@@ -6,6 +6,7 @@ use App\Models\CommentReaction;
 use App\Models\Message;
 use App\Models\MessageComment;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -142,7 +143,7 @@ class MessageCommentTest extends TestCase
     {
         $comment = MessageComment::factory()->create();
 
-        $this->assertInstanceOf(\Carbon\Carbon::class, $comment->created_at);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $comment->updated_at);
+        $this->assertInstanceOf(Carbon::class, $comment->created_at);
+        $this->assertInstanceOf(Carbon::class, $comment->updated_at);
     }
 }


### PR DESCRIPTION
## Summary
- Replaces per-user `localStorage` World Clock state (cities, appearance, timer, logo) with a single global server-side setting shared by everyone, synced live via a private Pusher/Echo channel.
- Adds `WorldClockSetting` model/migration, `WorldClockState::payload()` canonical shape, `WorldClockUpdated` broadcast event, and controller endpoints for settings/logo/timer updates.
- Adds `useWorldClockSync` composable as the client-side singleton source of truth (hydrate-once, remote-apply guards to prevent feedback loops, server-time-offset correction for the shared timer).
- The pinned "logo clock" now only stores which city is pinned — its face/hand/numeral appearance derives from the shared global clock style so it always matches the other clocks.

## Test plan
- [x] `npm run test:run` — all World Clock composable/component tests pass (21 tests)
- [x] `sail test --filter=WorldClockTest` — all feature tests pass (14 tests, 64 assertions)
- [ ] Manually verify in-browser: change appearance/cities/timer/logo on one session and confirm it live-updates on another session via Echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)