### PR TITLE
Fix mobile upload failures with chunked, resumable FilePond uploads

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,6 +22,11 @@ class Kernel extends ConsoleKernel
             ->timezone($weeklyTimezone)
             ->withoutOverlapping();
 
+        // Remove abandoned FilePond temporary uploads.
+        $schedule->command('filepond:clear')
+            ->daily()
+            ->withoutOverlapping();
+
         $schedule->command('users:generate-weekly-overviews')
             ->weeklyOn(0, '4:00')
             ->timezone($weeklyTimezone)

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
+use RahulHaque\Filepond\Facades\Filepond;
 
 class PageController extends Controller
 {
@@ -383,15 +384,29 @@ class PageController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(StorePageRequest $request): Redirector|RedirectResponse|JsonResponse
+    public function store(StorePageRequest $request): Redirector|RedirectResponse
     {
         $book = Book::find($request->book_id);
         $successMessage = __('messages.page.created');
 
-        if ($request->hasFile('image')) {
-            $file = $request->file('image');
+        // FilePond uploads each file to temporary storage (chunked/resumable) and
+        // submits the encrypted server ids in `images`. Resolve each back to its
+        // temporary file and queue the existing media-processing jobs.
+        $serverIds = array_filter((array) $request->input('images', []));
 
-            if ($file->isValid()) {
+        if (! empty($serverIds)) {
+            $files = Filepond::field($serverIds)->getFile();
+            $files = is_array($files) ? $files : [$files];
+
+            // Latitude/longitude are shared across the batch; fall back to the book.
+            $latitude = $request->input('latitude') ?? $book->latitude;
+            $longitude = $request->input('longitude') ?? $book->longitude;
+
+            foreach ($files as $file) {
+                if (! $file || ! $file->isValid()) {
+                    continue;
+                }
+
                 $mimeType = $file->getMimeType();
                 $originalName = $file->getClientOriginalName();
                 $filePath = Storage::disk('local')->put('temp', $file);
@@ -399,18 +414,12 @@ class PageController extends Controller
                 if (Str::startsWith($mimeType, 'image/')) {
                     $filename = pathinfo($file->hashName(), PATHINFO_FILENAME);
                     $mediaPath = 'books/'.$book->slug.'/'.$filename.'.webp';
-                    // Use book location as default if page doesn't have location
-                    $latitude = $request->input('latitude') ?? $book->latitude;
-                    $longitude = $request->input('longitude') ?? $book->longitude;
                     StoreImage::dispatch($filePath, $mediaPath, $book, $request->input('content'), $request->input('video_link'), null, null, null, $latitude, $longitude);
                     $successMessage = __('messages.page.queued_image', ['filename' => $originalName]);
                 } elseif (Str::startsWith($mimeType, 'video/')) {
                     $mediaPath = 'books/'.$book->slug.'/'.$originalName;
 
                     try {
-                        // Use book location as default if page doesn't have location
-                        $latitude = $request->input('latitude') ?? $book->latitude;
-                        $longitude = $request->input('longitude') ?? $book->longitude;
                         StoreVideo::dispatch($filePath, $mediaPath, $book, $request->input('content'), $request->input('video_link'), null, null, null, $latitude, $longitude);
                         $successMessage = __('messages.page.queued_video', ['filename' => $originalName]);
                     } catch (\Exception $e) {
@@ -425,13 +434,8 @@ class PageController extends Controller
                 }
             }
 
-            // The FilePond uploader posts via a plain XHR (no X-Inertia header)
-            // and only needs a lightweight acknowledgement. Returning JSON here
-            // avoids forcing the XHR to follow a 302 and download the full
-            // books.show HTML page, which adds latency and connection-drop risk.
-            if (! $request->header('X-Inertia')) {
-                return response()->json(['success' => true, 'message' => $successMessage]);
-            }
+            // Clear the FilePond temporary uploads now they have been queued.
+            Filepond::field($serverIds)->delete();
         } else {
             // If no file is uploaded, create the page immediately
             // Use book location as default if page doesn't have location

--- a/app/Http/Requests/StorePageRequest.php
+++ b/app/Http/Requests/StorePageRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Rules\AtLeastOneField;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StorePageRequest extends FormRequest
 {
@@ -26,14 +27,18 @@ class StorePageRequest extends FormRequest
     {
         return [
             'book_id' => 'integer|required',
-            'content' => ['string', 'nullable', new AtLeastOneField(['content', 'image', 'video_link'])],
-            'image' => [
-                'nullable',
-                'max:524288', // 512MB in kilobytes
-                'mimetypes:image/jpeg,image/jpg,image/png,image/bmp,image/gif,image/svg+xml,image/webp,video/mp4,video/avi,video/quicktime,video/mpeg,video/webm,video/x-matroska,application/octet-stream',
-                new AtLeastOneField(['content', 'image', 'video_link']),
+            'content' => ['string', 'nullable', new AtLeastOneField(['content', 'images', 'video_link'])],
+            // FilePond submits an array of encrypted temporary-upload ids. Each is
+            // validated against its temp file using the same media rules as before.
+            'images' => ['nullable', 'array', new AtLeastOneField(['content', 'images', 'video_link'])],
+            'images.*' => [
+                Rule::filepond([
+                    'required',
+                    'mimetypes:image/jpeg,image/jpg,image/png,image/bmp,image/gif,image/svg+xml,image/webp,video/mp4,video/avi,video/quicktime,video/mpeg,video/webm,video/x-matroska,application/octet-stream',
+                    'max:524288', // 512MB in kilobytes
+                ]),
             ],
-            'video_link' => ['string', 'nullable', new AtLeastOneField(['content', 'image', 'video_link'])],
+            'video_link' => ['string', 'nullable', new AtLeastOneField(['content', 'images', 'video_link'])],
             'category_id' => 'integer',
             'latitude' => 'nullable|numeric|between:-90,90',
             'longitude' => 'nullable|numeric|between:-180,180',

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "minishlink/web-push": "^9.0",
         "pbmedia/laravel-ffmpeg": "^8.5",
         "pusher/pusher-php-server": "^7.2",
+        "rahulhaque/laravel-filepond": "^13.0",
         "spatie/laravel-permission": "^6.0",
         "spatie/laravel-sluggable": "^3.4.2",
         "tightenco/ziggy": "^1.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1f82f3b42b278cdd0c17bacee3ecded",
+    "content-hash": "9abab82397ad49fcbe16356920a4a63e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4764,6 +4764,80 @@
                 "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
             },
             "time": "2026-05-18T13:11:36+00:00"
+        },
+        {
+            "name": "rahulhaque/laravel-filepond",
+            "version": "v13.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rahulhaque/laravel-filepond.git",
+                "reference": "b40d8a3f4f08b1e425e752a861fff02520e69609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rahulhaque/laravel-filepond/zipball/b40d8a3f4f08b1e425e752a861fff02520e69609",
+                "reference": "b40d8a3f4f08b1e425e752a861fff02520e69609",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^13.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.23",
+                "laravel/pail": "^1.2.5",
+                "laravel/pint": "^1.27",
+                "league/flysystem-aws-s3-v3": "^3.29",
+                "mockery/mockery": "^1.6",
+                "nunomaduro/collision": "^8.6",
+                "orchestra/testbench": "^11.0",
+                "phpunit/phpunit": "^12.5.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Filepond": "RahulHaque\\Filepond\\Facades\\Filepond"
+                    },
+                    "providers": [
+                        "RahulHaque\\Filepond\\FilepondServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "RahulHaque\\Filepond\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rahul Haque",
+                    "email": "rahulhaque07@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Use FilePond the Laravel way",
+            "homepage": "https://github.com/rahulhaque/laravel-filepond",
+            "keywords": [
+                "filepond",
+                "filepond-laravel",
+                "laravel-filepond"
+            ],
+            "support": {
+                "issues": "https://github.com/rahulhaque/laravel-filepond/issues",
+                "source": "https://github.com/rahulhaque/laravel-filepond/tree/v13.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/rahulhaque",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-03-29T21:33:28+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/config/filepond.php
+++ b/config/filepond.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+use RahulHaque\Filepond\Http\Controllers\FilepondController;
+use RahulHaque\Filepond\Models\Filepond;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | FilePond Permanent Disk
+    |--------------------------------------------------------------------------
+    |
+    | Set the FilePond default disk to be used for permanent file storage.
+    |
+    */
+    'disk' => env('FILEPOND_DISK', 'public'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | FilePond Temporary Disk
+    |--------------------------------------------------------------------------
+    |
+    | Set the FilePond temporary disk and folder name to be used for temporary
+    | storage. This disk will be used for temporary file storage and cleared
+    | upon running the "artisan filepond:clear" command. It is recommended to
+    | use local disk for temporary storage when you want to take advantage of
+    | controller level validation. File validation from third party storage is
+    | not yet supported. However, global 'validation_rules' defined in this
+    | config will work fine.
+    |
+    */
+    'temp_disk' => 'local',
+    'temp_folder' => 'filepond/temp',
+
+    /*
+    |--------------------------------------------------------------------------
+    | FilePond Routes Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Default middleware for FilePond routes.
+    |
+    */
+    'middleware' => [
+        'web', 'auth', 'can:edit pages',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Delete FilePond Model
+    |--------------------------------------------------------------------------
+    |
+    | Determine whether to enable or disable soft delete in FilePond model.
+    |
+    */
+    'soft_delete' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Delete After (Minutes)
+    |--------------------------------------------------------------------------
+    |
+    | Set the minutes after which the FilePond temporary storage files will be
+    | deleted while running 'artisan filepond:clear' command.
+    |
+    */
+    'expiration' => 60,
+
+    /*
+    |--------------------------------------------------------------------------
+    | FilePond Controller
+    |--------------------------------------------------------------------------
+    |
+    | FilePond controller determines how the requests from FilePond library is
+    | processed.
+    |
+    */
+    'controller' => FilepondController::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | FilePond Model
+    |--------------------------------------------------------------------------
+    |
+    | Set the filepond model to be used by the package. Make sure you extend
+    | the custom model with "RahulHaque\Filepond\Models\Filepond" model.
+    |
+    */
+    'model' => Filepond::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Global Validation Rules
+    |--------------------------------------------------------------------------
+    |
+    | Set the default validation for filepond's ./process route. In other words
+    | temporary file upload validation.
+    |
+    */
+    // Mirror the existing StorePageRequest media rules so the temporary upload is
+    // validated (and large files are allowed) the moment FilePond sends it.
+    'validation_rules' => [
+        'required',
+        'file',
+        'mimetypes:image/jpeg,image/jpg,image/png,image/bmp,image/gif,image/svg+xml,image/webp,video/mp4,video/avi,video/quicktime,video/mpeg,video/webm,video/x-matroska,application/octet-stream',
+        'max:524288', // 512MB in kilobytes
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | FilePond Server Paths
+    |--------------------------------------------------------------------------
+    |
+    | Configure url for each of the FilePond actions.
+    | See details - https://pqina.nl/filepond/docs/patterns/api/server/
+    |
+    */
+    'server' => [
+        'url' => env('FILEPOND_URL', '/filepond'),
+    ],
+];

--- a/database/migrations/2026_06_18_011033_create_fileponds_table.php
+++ b/database/migrations/2026_06_18_011033_create_fileponds_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('fileponds', function (Blueprint $table) {
+            $table->id();
+            $table->string('filename');
+            $table->string('filepath');
+            $table->string('extension', 100);
+            $table->string('mimetype', 100);
+            $table->json('metadata')->nullable();
+            $table->string('disk', 100);
+            $table->text('upload_id')->nullable();
+            $table->json('upload_tags')->nullable();
+            $table->foreignId('created_by')->nullable()->index();
+            $table->dateTime('expires_at')->nullable()->index();
+            $table->dateTime('deleted_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('fileponds');
+    }
+};

--- a/resources/js/Components/FilePondUploader.vue
+++ b/resources/js/Components/FilePondUploader.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { usePage } from "@inertiajs/vue3";
-import { defineExpose, onMounted, ref, watch } from "vue";
+import { ref } from "vue";
+import { FileStatus } from "filepond";
 import vueFilePond from "vue-filepond";
 // Import FilePond styles
 import "filepond-plugin-file-poster/dist/filepond-plugin-file-poster.css";
@@ -15,230 +16,99 @@ import FilePondPluginImagePreview from "filepond-plugin-image-preview";
 import FilePondPluginMediaPreview from "filepond-plugin-media-preview";
 
 const emit = defineEmits([
-  "error",
-  "processed",
-  "all-done",
-  "queue-update",
-  "processing-start"
+    "error",
+    "all-done",
+    "queue-update",
+    "processing-start",
 ]);
 
-const props = defineProps({
-  uploadUrl: { type: String, required: true },
-  allowMultiple: { type: Boolean, default: false },
-  acceptedFileTypes: { type: Array, default: () => ["image/*", "video/*"] },
-  extraData: { type: Object, default: () => ({}) },
-  labelIdle: {
-    type: String,
-    default:
-      'Drag & Drop your files or <span class="filepond--label-action">Browse</span>'
-  },
-  instantUpload: { type: Boolean, default: false },
-  maxFileSize: { type: [String, Number], default: null } // e.g. '512MB' or 536870912
+defineProps({
+    allowMultiple: { type: Boolean, default: false },
+    acceptedFileTypes: { type: Array, default: () => ["image/*", "video/*"] },
+    labelIdle: {
+        type: String,
+        default:
+            'Drag & Drop your files or <span class="filepond--label-action">Browse</span>',
+    },
+    maxFileSize: { type: [String, Number], default: null }, // e.g. '512MB' or 536870912
 });
 
 const FilePond = vueFilePond(
-  FilePondPluginFileValidateType,
-  FilePondPluginImagePreview,
-  FilePondPluginFilePoster,
-  FilePondPluginMediaPreview
+    FilePondPluginFileValidateType,
+    FilePondPluginImagePreview,
+    FilePondPluginFilePoster,
+    FilePondPluginMediaPreview
 );
 
 const pond = ref(null);
+const files = ref([]);
 const page = usePage();
 
-const calculateUploadTimeout = (fileSizeBytes) => {
-  const MIN_TIMEOUT_MS = 5 * 60 * 1000;
-  const MAX_TIMEOUT_MS = 2 * 60 * 60 * 1000;
-  const MIN_BANDWIDTH_BYTES_PER_SEC = 62500;
-  const BUFFER_MULTIPLIER = 1.5;
-
-  if (!fileSizeBytes || fileSizeBytes <= 0) {
-    return MIN_TIMEOUT_MS;
-  }
-
-  const calculatedTimeout =
-    (fileSizeBytes / MIN_BANDWIDTH_BYTES_PER_SEC) * BUFFER_MULTIPLIER * 1000;
-
-  return Math.max(MIN_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, calculatedTimeout));
-};
-
+// laravel-filepond exposes every action on the same /filepond URL, differentiated
+// by HTTP verb (POST/PATCH/HEAD/DELETE). FilePond's transfer layer handles the
+// chunked + resumable upload, so a dropped chunk on a flaky mobile connection is
+// retried/resumed instead of failing the whole file.
 const server = {
-  process: (
-    fieldName,
-    originalFile,
-    metadata,
-    load,
-    error,
-    progress,
-    abort
-  ) => {
-    let aborted = false;
-    let xhr = null;
-
-    const send = async () => {
-      const file = originalFile;
-
-      const formData = new FormData();
-      formData.append("image", file);
-
-      Object.keys(props.extraData).forEach((key) => {
-        formData.append(key, props.extraData[key]);
-      });
-
-      xhr = new XMLHttpRequest();
-
-      xhr.upload.addEventListener("progress", (e) => {
-        if (!aborted && e.lengthComputable) {
-          progress(true, e.loaded, e.total);
-        }
-      });
-
-      xhr.addEventListener("load", () => {
-        if (aborted) return;
-
-        if (xhr.status >= 200 && xhr.status < 300) {
-          try {
-            const response = JSON.parse(xhr.responseText);
-            const serverId = response?.id || `${Date.now()}`;
-            load(serverId);
-            emit("processed", {
-              name: file.name,
-              size: file.size,
-              type: file.type
-            });
-          } catch (_e) {
-            load(`${Date.now()}`);
-          }
-        } else {
-          let serverMsg = "";
-          try {
-            serverMsg = JSON.parse(xhr.responseText)?.message || "";
-          } catch (_e) {
-            // response wasn't JSON (e.g. an HTML error page)
-          }
-          const errorMsg = serverMsg
-            ? `Upload failed (${xhr.status}): ${serverMsg}`
-            : `Upload failed (${xhr.status})`;
-          emit("error", errorMsg);
-          error(errorMsg);
-        }
-      });
-
-      xhr.addEventListener("error", () => {
-        if (aborted) return;
-        const errorMsg = "Upload failed due to network error";
-        emit("error", errorMsg);
-        error(errorMsg);
-      });
-
-      xhr.addEventListener("timeout", () => {
-        if (aborted) return;
-        const errorMsg =
-          "Upload timed out. The file may be too large or your connection is slow.";
-        emit("error", errorMsg);
-        error(errorMsg);
-      });
-
-      xhr.open("POST", props.uploadUrl);
-      xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-      xhr.setRequestHeader("X-CSRF-TOKEN", page.props.csrf_token);
-      xhr.timeout = calculateUploadTimeout(file.size);
-
-      xhr.send(formData);
-    };
-
-    // initial send
-    send();
-
-    return {
-      abort: () => {
-        aborted = true;
-        if (xhr) {
-          xhr.abort();
-        }
-        abort();
-      }
-    };
-  },
-  revert: null
+    url: "/filepond",
+    headers: { "X-CSRF-TOKEN": page.props.csrf_token },
 };
 
-// FilePond ItemStatus values we care about.
-const STATUS = {
-  PROCESSING: 3,
-  PROCESSING_COMPLETE: 5,
-  PROCESSING_ERROR: 6,
-  LOADING: 7,
-  LOAD_ERROR: 8,
-  PROCESSING_QUEUED: 9
-};
-
-const isActive = (s) =>
-  s === STATUS.PROCESSING ||
-  s === STATUS.PROCESSING_QUEUED ||
-  s === STATUS.LOADING;
-const isErrored = (s) =>
-  s === STATUS.PROCESSING_ERROR || s === STATUS.LOAD_ERROR;
-
-const files = ref([]);
-watch(files, (newFiles) => {
-  try {
-    emit("queue-update", Array.isArray(newFiles) ? newFiles.length : 0);
-  } catch (_e) {
-    // ignore
-  }
-
-  if (!newFiles.length) return;
-
-  // Wait until nothing is actively uploading/queued before deciding.
-  if (newFiles.some((f) => isActive(f.status))) return;
-
-  // Only signal "all-done" on a clean batch: at least one completed upload and
-  // no errored files. If any file errored we keep it in the queue (status
-  // PROCESSING_ERROR) so the Retry button has something to re-process instead
-  // of wiping the queue and closing the form.
-  const anyErrored = newFiles.some((f) => isErrored(f.status));
-  const anyComplete = newFiles.some(
-    (f) => f.status === STATUS.PROCESSING_COMPLETE
-  );
-  if (!anyErrored && anyComplete) {
-    emit("all-done");
-  }
-});
-
-// Process all queued/errored files. Calling processFiles() with no arguments
-// lets FilePond decide what to (re)process: it skips files that are already
-// PROCESSING_COMPLETE so a retry never re-uploads files that already succeeded,
-// while errored files (PROCESSING_ERROR) are re-queued.
-const process = () => pond.value?.processFiles();
+// Encrypted temporary-upload ids for files that finished uploading. These are
+// submitted with the form and resolved back to files server-side.
+const getServerIds = () =>
+    (pond.value?.getFiles?.() || []).map((f) => f.serverId).filter(Boolean);
 const getFileCount = () => (pond.value?.getFiles?.() || []).length;
 const removeFiles = () => pond.value?.removeFiles?.();
+// FilePond's documented retry/resume — re-processes queued or errored items.
+const process = () => pond.value?.processFiles?.();
 
-defineExpose({ process, getFileCount, removeFiles, getPond: () => pond.value });
+defineExpose({
+    getServerIds,
+    getFileCount,
+    removeFiles,
+    process,
+    getPond: () => pond.value,
+});
 
-onMounted(() => {});
+const onProcessFile = (error) => {
+    if (error) {
+        emit("error", error.body || error.main || "Upload failed.");
+    }
+};
 
-// Completion is signalled by the status-aware watch on `files`, not here, so a
-// batch that finished with errors does not get treated as a success.
-const oninit = () => {};
+const onProcessFiles = () => {
+    // Batch finished. Only signal success when no file is left in an error state,
+    // so errored files stay in the queue for the user to retry.
+    const hasError = (pond.value?.getFiles?.() || []).some(
+        (f) => f.status === FileStatus.PROCESSING_ERROR
+    );
+    if (!hasError) {
+        emit("all-done");
+    }
+};
 
-const onUpdateFiles = (newFileList) => {
-  emit("queue-update", newFileList.length);
+const onUpdateFiles = (items) => {
+    emit("queue-update", items.length);
 };
 </script>
 
 <template>
-  <FilePond
-    ref="pond"
-    v-model="files"
-    :allow-multiple="allowMultiple"
-    :accepted-file-types="acceptedFileTypes"
-    :server="server"
-    :instant-upload="instantUpload"
-    :label-idle="labelIdle"
-    :oninit="oninit"
-    credits="false"
-    @processfilestart="$emit('processing-start')"
-    @updatefiles="onUpdateFiles"
-  />
+    <FilePond
+        ref="pond"
+        v-model="files"
+        :allow-multiple="allowMultiple"
+        :accepted-file-types="acceptedFileTypes"
+        :server="server"
+        :chunk-uploads="true"
+        :chunk-size="5242880"
+        :chunk-retry-delays="[500, 1000, 3000]"
+        :max-file-size="maxFileSize"
+        :label-idle="labelIdle"
+        name="image"
+        credits="false"
+        @processfilestart="$emit('processing-start')"
+        @processfile="onProcessFile"
+        @processfiles="onProcessFiles"
+        @updatefiles="onUpdateFiles"
+    />
 </template>

--- a/resources/js/Pages/Book/NewPageForm.test.js
+++ b/resources/js/Pages/Book/NewPageForm.test.js
@@ -3,7 +3,7 @@ import { validateFile } from "@/utils/fileValidation.js";
 import { useForm, usePage } from "@inertiajs/vue3";
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { nextTick, ref } from "vue";
+import { nextTick } from "vue";
 
 global.route = (name) => `/${name}`;
 
@@ -84,21 +84,19 @@ vi.mock("@/Components/FilePondUploader.vue", () => ({
     default: {
         name: "FilePondUploader",
         props: [
-            "uploadUrl",
             "allowMultiple",
             "acceptedFileTypes",
-            "instantUpload",
-            "extraData",
-            "processVideo",
-            "videoThresholdBytes",
+            "maxFileSize",
+            "labelIdle",
         ],
         template:
-            '<div class="filepond-uploader" @click="$emit(\'processed\')"></div>',
-        // Expose methods so parent can call uploaderRef.process() and getFileCount()
+            '<div class="filepond-uploader" @click="$emit(\'all-done\')"></div>',
+        // Expose methods so parent can call uploaderRef.getServerIds() etc.
         setup(props, { expose }) {
             const api = {
                 process: vi.fn(),
                 getFileCount: vi.fn(() => 0),
+                getServerIds: vi.fn(() => ["srv-1"]),
                 removeFiles: vi.fn(),
             };
             expose(api);
@@ -122,7 +120,7 @@ describe("NewPageForm", () => {
     const createMockForm = () => ({
         book_id: 1,
         content: "",
-        image: null,
+        images: [],
         video_link: null,
         errors: {},
         processing: false,
@@ -294,28 +292,29 @@ describe("NewPageForm", () => {
             expect(validateFile(largeFile).sizeError).toBe(true);
         });
 
-        it("calls FilePond process when files are queued and submit clicked", async () => {
+        it("submits uploaded file server ids and closes the form", async () => {
             // Wait for FilePondUploader to mount
             await nextTick();
-            // Simulate files are queued
-            if (
-                !wrapper.vm.pondQueueCount ||
-                typeof wrapper.vm.pondQueueCount !== "object" ||
-                !("value" in wrapper.vm.pondQueueCount)
-            ) {
-                wrapper.vm.pondQueueCount = ref(1);
-            } else {
-                wrapper.vm.pondQueueCount.value = 1;
-            }
-            await nextTick();
 
-            await wrapper.vm.handleFormSubmit();
-
-            // Simulate upload completion
+            // Files have finished uploading to temporary storage.
             const pond = wrapper.findComponent({ name: "FilePondUploader" });
+            pond.vm.$emit("queue-update", 1);
             pond.vm.$emit("all-done");
             await nextTick();
-            // Assert the form closes
+
+            // Inertia submit succeeds.
+            mockForm.post = vi.fn((url, options) => {
+                if (options && options.onSuccess) {
+                    options.onSuccess();
+                }
+            });
+
+            await wrapper.vm.handleFormSubmit();
+            await nextTick();
+
+            // The encrypted server ids are submitted and the form closes.
+            expect(mockForm.images).toEqual(["srv-1"]);
+            expect(mockForm.post).toHaveBeenCalled();
             expect(wrapper.emitted("close-form")).toBeTruthy();
         });
     });

--- a/resources/js/Pages/Book/NewPageForm.vue
+++ b/resources/js/Pages/Book/NewPageForm.vue
@@ -3,8 +3,8 @@
 import Button from "@/Components/Button.vue";
 import InputError from "@/Components/InputError.vue";
 import {
-  default as BreezeLabel,
-  default as InputLabel
+    default as BreezeLabel,
+    default as InputLabel,
 } from "@/Components/InputLabel.vue";
 
 import FilePondUploader from "@/Components/FilePondUploader.vue";
@@ -25,27 +25,23 @@ const { speak } = useSpeechSynthesis();
 const { t } = useTranslations();
 
 const props = defineProps({
-  book: { type: Object, required: true }
+    book: { type: Object, required: true },
 });
 
 const isYouTubeEnabled = computed(
-  () => usePage().props.settings["youtube_enabled"]
+    () => usePage().props.settings["youtube_enabled"]
 );
 
 const form = useForm({
-  book_id: props.book.id,
-  content: "",
-  image: null,
-  video_link: null,
-  latitude: null,
-  longitude: null
+    book_id: props.book.id,
+    content: "",
+    images: [],
+    video_link: null,
+    latitude: null,
+    longitude: null,
 });
 
 const mediaOption = ref("upload"); // upload, link
-
-const getPagesStoreUrl = () => {
-  return route("pages.store");
-};
 
 // Auto-save draft functionality
 const draftKey = computed(() => `page-draft-${props.book.id}`);
@@ -54,488 +50,484 @@ const draftSaved = ref(false);
 const autoSaveTimeout = ref(null);
 
 const saveDraft = () => {
-  const hasContent =
-    form.content && form.content !== "<p></p>" && form.content.trim() !== "";
-  const hasVideoLink = form.video_link && form.video_link.trim();
+    const hasContent =
+        form.content &&
+        form.content !== "<p></p>" &&
+        form.content.trim() !== "";
+    const hasVideoLink = form.video_link && form.video_link.trim();
 
-  if (hasContent || hasVideoLink) {
-    try {
-      localStorage.setItem(
-        draftKey.value,
-        JSON.stringify({
-          content: form.content,
-          video_link: form.video_link,
-          timestamp: Date.now()
-        })
-      );
-      draftSaved.value = true;
-      setTimeout(() => {
-        draftSaved.value = false;
-      }, 2000);
-    } catch (error) {
-      // ignore
+    if (hasContent || hasVideoLink) {
+        try {
+            localStorage.setItem(
+                draftKey.value,
+                JSON.stringify({
+                    content: form.content,
+                    video_link: form.video_link,
+                    timestamp: Date.now(),
+                })
+            );
+            draftSaved.value = true;
+            setTimeout(() => {
+                draftSaved.value = false;
+            }, 2000);
+        } catch (error) {
+            // ignore
+        }
+    } else {
+        clearDraft();
     }
-  } else {
-    clearDraft();
-  }
 
-  autoSaveTimeout.value = null;
+    autoSaveTimeout.value = null;
 };
 
 const loadDraft = () => {
-  const saved = localStorage.getItem(draftKey.value);
-  if (saved) {
-    try {
-      const draft = JSON.parse(saved);
-      if (Date.now() - draft.timestamp < 24 * 60 * 60 * 1000) {
-        form.content = draft.content || "";
-        form.video_link = draft.video_link || null;
-        hasDraft.value = true;
-        mediaOption.value = draft.video_link ? "link" : "upload";
-      } else {
-        clearDraft();
-      }
-    } catch (error) {
-      clearDraft();
+    const saved = localStorage.getItem(draftKey.value);
+    if (saved) {
+        try {
+            const draft = JSON.parse(saved);
+            if (Date.now() - draft.timestamp < 24 * 60 * 60 * 1000) {
+                form.content = draft.content || "";
+                form.video_link = draft.video_link || null;
+                hasDraft.value = true;
+                mediaOption.value = draft.video_link ? "link" : "upload";
+            } else {
+                clearDraft();
+            }
+        } catch (error) {
+            clearDraft();
+        }
     }
-  }
 };
 
 const clearDraft = (resetForm = false) => {
-  localStorage.removeItem(draftKey.value);
-  hasDraft.value = false;
-  draftSaved.value = false;
+    localStorage.removeItem(draftKey.value);
+    hasDraft.value = false;
+    draftSaved.value = false;
 
-  if (resetForm) {
-    form.content = "";
-    form.video_link = null;
-    mediaOption.value = "upload";
-  }
+    if (resetForm) {
+        form.content = "";
+        form.video_link = null;
+        mediaOption.value = "upload";
+    }
 };
 
 // Watch for changes and auto-save
 watch(
-  [() => form.content, () => form.video_link],
-  (newValues, oldValues) => {
-    if (JSON.stringify(newValues) !== JSON.stringify(oldValues)) {
-      clearTimeout(autoSaveTimeout.value);
-      autoSaveTimeout.value = setTimeout(() => {
-        saveDraft();
-      }, 1000);
-    }
-  },
-  { deep: true }
+    [() => form.content, () => form.video_link],
+    (newValues, oldValues) => {
+        if (JSON.stringify(newValues) !== JSON.stringify(oldValues)) {
+            clearTimeout(autoSaveTimeout.value);
+            autoSaveTimeout.value = setTimeout(() => {
+                saveDraft();
+            }, 1000);
+        }
+    },
+    { deep: true }
 );
 
-// FilePond integration
+// FilePond integration. Files upload to temporary storage (chunked/resumable) as
+// soon as they are selected; the form submit just references the resulting ids.
 const uploaderRef = ref(null);
 const pondQueueCount = ref(0);
 const isUploading = ref(false);
 
-const pondUploadUrl = computed(() => getPagesStoreUrl());
-const pondExtraData = computed(() => {
-  const data = {
-    book_id: form.book_id,
-    content: form.content || ""
-    // Don't pass video_link to file uploads since that's for text-only submissions
-  };
-
-  // Only include latitude/longitude if they have values (not null)
-  if (form.latitude != null) {
-    data.latitude = form.latitude;
-  }
-  if (form.longitude != null) {
-    data.longitude = form.longitude;
-  }
-
-  return data;
-});
-
 const hasQueuedFiles = computed(() => {
-  const count = Number(pondQueueCount.value) || 0;
-  const refCount = Number(uploaderRef.value?.getFileCount?.() || 0);
-  return count > 0 || refCount > 0;
+    const count = Number(pondQueueCount.value) || 0;
+    const refCount = Number(uploaderRef.value?.getFileCount?.() || 0);
+    return count > 0 || refCount > 0;
 });
 
 const onPondQueueUpdate = (count) => {
-  pondQueueCount.value = Number(count) || 0;
+    pondQueueCount.value = Number(count) || 0;
 };
 
 const onPondProcessingStart = () => {
-  isUploading.value = true;
+    isUploading.value = true;
 };
 
-const onPondProcessed = () => {
-  // no-op per file; FilePond handles progress
-};
-
+// Temporary uploads finished — the files are now ready to submit.
 const onPondAllDone = () => {
-  speak(t("page.uploads_batch_queued_speech"));
-  try {
-    uploaderRef.value?.removeFiles?.();
-  } catch (e) {
-    // ignore remove files error
-  }
-  clearDraft();
-  form.reset();
-  isUploading.value = false;
-  emit("close-form");
+    isUploading.value = false;
 };
 
 // Simple UI error helpers
 const singleError = ref(null);
 const scrollToSingleError = () => {
-  try {
-    const el = document.querySelector("[data-single-error]");
-    if (el && typeof el.scrollIntoView === "function") {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
+    try {
+        const el = document.querySelector("[data-single-error]");
+        if (el && typeof el.scrollIntoView === "function") {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+    } catch (e) {
+        // ignore scroll errors
     }
-  } catch (e) {
-    // ignore scroll errors
-  }
 };
 
 // Validation rules (rely on FilePond for file type/size)
 const rules = computed(() => {
-  const atLeastOneRequired = () => {
-    if (hasQueuedFiles.value) return true;
-    return (
-      form.video_link || (form.content !== "" && form.content !== "<p></p>")
-    );
-  };
+    const atLeastOneRequired = () => {
+        if (hasQueuedFiles.value) return true;
+        return (
+            form.video_link ||
+            (form.content !== "" && form.content !== "<p></p>")
+        );
+    };
 
-  return {
-    form: {
-      video_link: { required: atLeastOneRequired },
-      image: { required: atLeastOneRequired },
-      content: { required: atLeastOneRequired }
-    }
-  };
+    return {
+        form: {
+            video_link: { required: atLeastOneRequired },
+            images: { required: atLeastOneRequired },
+            content: { required: atLeastOneRequired },
+        },
+    };
 });
 
 let v$ = useVuelidate(rules, form);
 
 // Submit handlers
-const handleFormSubmit = async (event) => {
-  if (event) event.preventDefault();
+const handleFormSubmit = (event) => {
+    if (event) event.preventDefault();
+    singleError.value = null;
 
-  if (mediaOption.value === "upload") {
-    const queued =
-      hasQueuedFiles.value || uploaderRef.value?.getFileCount?.() > 0;
-    if (queued) {
-      singleError.value = null;
-      try {
-        // Immediately reflect uploading state in the UI
+    if (mediaOption.value === "upload" && hasQueuedFiles.value) {
+        // Files upload to temporary storage automatically; wait until they finish.
+        if (isUploading.value) {
+            singleError.value = "Please wait for the upload to finish.";
+            scrollToSingleError();
+            return;
+        }
+        const serverIds = uploaderRef.value?.getServerIds?.() || [];
+        if (!serverIds.length) {
+            singleError.value = "No files were uploaded. Please try again.";
+            scrollToSingleError();
+            return;
+        }
+        form.images = serverIds;
+        submitPage();
+        return;
+    }
+
+    submitTextOrLinkOnly();
+};
+
+const submitPage = () => {
+    form.post(route("pages.store"), {
+        preserveScroll: true,
+        onSuccess: () => {
+            speak(t("page.uploads_batch_queued_speech"));
+            try {
+                uploaderRef.value?.removeFiles?.();
+            } catch (e) {
+                // ignore remove files error
+            }
+            clearDraft();
+            form.reset();
+            emit("close-form");
+        },
+        onError: (errors) => {
+            singleError.value =
+                errors?.message ||
+                Object.values(errors)[0] ||
+                "Submission failed.";
+            scrollToSingleError();
+        },
+    });
+};
+
+const submitTextOrLinkOnly = () => {
+    // Guard: require content or video_link
+    const hasText =
+        form.content && form.content.trim() && form.content !== "<p></p>";
+    if (!hasText && !form.video_link) {
+        singleError.value = "Please add some words or a YouTube link.";
+        scrollToSingleError();
+        return;
+    }
+
+    // Use Inertia form to submit - it handles CSRF automatically
+    form.post(route("pages.store"), {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => {
+            clearDraft();
+            form.reset();
+            emit("close-form");
+        },
+        onError: (errors) => {
+            singleError.value =
+                errors?.message ||
+                Object.values(errors)[0] ||
+                "Submission failed.";
+            scrollToSingleError();
+        },
+    });
+};
+
+// Retry resumes errored/queued temporary uploads; otherwise re-submits the form.
+const handleRetry = () => {
+    singleError.value = null;
+    const fileCount = uploaderRef.value?.getFileCount?.() || 0;
+    const idCount = (uploaderRef.value?.getServerIds?.() || []).length;
+    if (mediaOption.value === "upload" && fileCount > idCount) {
         isUploading.value = true;
         uploaderRef.value?.process?.();
-      } catch (e) {
-        isUploading.value = false; // reset on sync failure
-        singleError.value = e?.message || "Upload failed.";
-        scrollToSingleError();
-      }
-      return;
+        return;
     }
-  }
-
-  // Otherwise submit text / youtube link only
-  try {
-    await submitTextOrLinkOnly();
-  } catch (e) {
-    singleError.value = e?.message || "Submission failed.";
-    scrollToSingleError();
-  }
-};
-
-// Handle "Upload All" button - uses FilePond's native processFiles() method
-const handleUploadAll = () => {
-  singleError.value = null;
-  try {
-    isUploading.value = true;
-    uploaderRef.value?.process?.();
-  } catch (e) {
-    isUploading.value = false;
-    singleError.value = e?.message || "Upload failed.";
-    scrollToSingleError();
-  }
-};
-
-const submitTextOrLinkOnly = async () => {
-  // Guard: require content or video_link
-  const hasText =
-    form.content && form.content.trim() && form.content !== "<p></p>";
-  if (!hasText && !form.video_link) {
-    throw new Error("Please add some words or a YouTube link.");
-  }
-
-  // Use Inertia form to submit - it handles CSRF automatically
-  form.post(route("pages.store"), {
-    preserveScroll: true,
-    preserveState: true,
-    onSuccess: () => {
-      clearDraft();
-      form.reset();
-      emit("close-form");
-    },
-    onError: (errors) => {
-      const errorMessage =
-        errors?.message || Object.values(errors)[0] || "Submission failed.";
-      throw new Error(errorMessage);
-    }
-  });
+    handleFormSubmit();
 };
 
 // FilePond event handlers
 const onPondError = (msg) => {
-  singleError.value = msg || "Upload error.";
-  // Reset uploading state so the UI isn't stuck on "Uploading..." and the
-  // main/Retry buttons become interactive again.
-  isUploading.value = false;
-  scrollToSingleError();
+    singleError.value = msg || "Upload error.";
+    // Reset uploading state so the UI isn't stuck on "Uploading..." and the
+    // main/Retry buttons become interactive again.
+    isUploading.value = false;
+    scrollToSingleError();
 };
 
 // Lifecycle
 onMounted(() => {
-  loadDraft();
+    loadDraft();
 });
 
 onUnmounted(() => {
-  // no-op (FilePond cleans itself)
+    // no-op (FilePond cleans itself)
 });
 
 const handleAddressFocus = () => {
-  isLocationOpen.value = true;
+    isLocationOpen.value = true;
 };
 </script>
 
 <template>
-  <div class="bg-white dark:bg-gray-800 rounded m-5 md:w-full p-10">
-    <h3 class="text-2xl dark:text-gray-100 w-full border-b mb-7">
-      Add New Page
-    </h3>
+    <div class="bg-white dark:bg-gray-800 rounded m-5 md:w-full p-10">
+        <h3 class="text-2xl dark:text-gray-100 w-full border-b mb-7">
+            Add New Page
+        </h3>
 
-    <!-- Draft Status Indicators -->
-    <div v-if="hasDraft || draftSaved" class="mb-4">
-      <div
-        v-if="hasDraft"
-        class="mb-2 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded text-sm"
-      >
-        <div class="flex items-center justify-between">
-          <div
-            class="flex items-center space-x-2 text-blue-700 dark:text-blue-300"
-          >
-            <i class="ri-file-text-line w-4 h-4"></i>
-            <span
-              >📝 Draft restored (text & YouTube links only - files need to be
-              re-selected)</span
-            >
-          </div>
-          <button
-            type="button"
-            class="text-xs px-2 py-1 bg-blue-100 hover:bg-blue-200 dark:bg-blue-800 dark:hover:bg-blue-700 rounded text-blue-700 dark:text-blue-300"
-            @click="clearDraft(true)"
-          >
-            Clear Draft
-          </button>
-        </div>
-      </div>
-      <div
-        v-if="draftSaved"
-        class="mb-2 p-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded text-sm"
-      >
-        <div
-          class="flex items-center space-x-2 text-green-700 dark:text-green-300"
-        >
-          <i class="ri-check-line w-4 h-4"></i>
-          <span>💾 Draft saved</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- General Upload Error -->
-    <div
-      v-if="singleError"
-      data-single-error
-      class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm"
-    >
-      <div
-        class="flex items-center justify-between text-red-700 dark:text-red-300"
-      >
-        <div class="flex items-center space-x-2">
-          <i class="ri-error-warning-line w-4 h-4"></i>
-          <span class="font-medium">Upload Error</span>
-        </div>
-        <div class="flex items-center gap-2">
-          <button
-            type="button"
-            class="text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 rounded text-gray-700 dark:text-gray-200"
-            @click="handleFormSubmit"
-          >
-            Retry
-          </button>
-          <button
-            type="button"
-            class="text-xs px-2 py-1 bg-red-100 hover:bg-red-200 dark:bg-red-800 dark:hover:bg-red-700 rounded text-red-700 dark:text-red-300"
-            @click="singleError = null"
-          >
-            Dismiss
-          </button>
-        </div>
-      </div>
-      <div class="mt-2 text-red-700 dark:text-red-300">
-        {{ singleError }}
-      </div>
-    </div>
-
-    <form enctype="multipart/form-data" @submit.prevent>
-      <!-- Media Type Selection -->
-      <div v-if="isYouTubeEnabled" class="mb-4">
-        <div class="flex flex-wrap gap-2 mb-2">
-          <Button
-            :is-active="mediaOption === 'upload'"
-            class="rounded-none w-24 justify-center text-sm"
-            @click.prevent="mediaOption = 'upload'"
-          >
-            Upload
-          </Button>
-          <Button
-            :is-active="mediaOption === 'link'"
-            class="rounded-none w-24 justify-center text-sm"
-            @click.prevent="mediaOption = 'link'"
-          >
-            YouTube
-          </Button>
-        </div>
-      </div>
-
-      <!-- Media Type Selection (when YouTube is disabled) -->
-      <div v-else class="mb-4">
-        <div class="flex flex-wrap gap-2 mb-2">
-          <Button
-            :is-active="mediaOption === 'upload'"
-            class="rounded-none w-24 justify-center text-sm"
-            @click.prevent="mediaOption = 'upload'"
-          >
-            Upload
-          </Button>
-        </div>
-      </div>
-
-      <div class="flex flex-wrap">
-        <!-- Upload Section -->
-        <div v-if="mediaOption === 'upload'" class="w-full mb-2">
-          <BreezeLabel for="imageInput" value="Media" />
-
-          <!-- FilePond Uploader -->
-          <div>
-            <FilePondUploader
-              ref="uploaderRef"
-              :upload-url="pondUploadUrl"
-              :allow-multiple="true"
-              :accepted-file-types="['image/*', 'video/*']"
-              :instant-upload="false"
-              :extra-data="pondExtraData"
-              @queue-update="onPondQueueUpdate"
-              @processing-start="onPondProcessingStart"
-              @error="onPondError"
-              @processed="onPondProcessed"
-              @all-done="onPondAllDone"
-            />
-          </div>
-        </div>
-
-        <!-- YouTube Link Section -->
-        <div v-if="mediaOption === 'link'" class="w-full mr-2">
-          <InputLabel for="media-link" value="YouTube Link" />
-          <TextInput
-            id="media-link"
-            v-model="form.video_link"
-            class="mt-1 mb-3 block w-full"
-            placeholder="https://youtube.com/watch?v=..."
-          />
-          <InputError
-            v-if="v$.$errors.length && v$.form.video_link.required.$invalid"
-            class="mt-2"
-            message="A link to a video is required without any text or upload."
-          />
-
-          <div v-if="form.video_link" class="w-1/2">
-            <VideoWrapper :url="form.video_link" :controls="false" />
-          </div>
-        </div>
-
-        <!-- Content Section -->
-        <div class="w-full">
-          <BreezeLabel for="content" :value="'Words'" />
-          <div class="relative">
-            <Wysiwyg
-              id="content"
-              v-model="form.content"
-              class="mt-1 block w-full"
-            />
-            <!-- Auto-save indicator -->
+        <!-- Draft Status Indicators -->
+        <div v-if="hasDraft || draftSaved" class="mb-4">
             <div
-              v-if="autoSaveTimeout"
-              class="absolute top-2 right-2 text-xs text-gray-500 bg-white px-2 py-1 rounded border"
+                v-if="hasDraft"
+                class="mb-2 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded text-sm"
             >
-              ⏱️ Auto-saving in 1s...
+                <div class="flex items-center justify-between">
+                    <div
+                        class="flex items-center space-x-2 text-blue-700 dark:text-blue-300"
+                    >
+                        <i class="ri-file-text-line w-4 h-4"></i>
+                        <span
+                            >📝 Draft restored (text & YouTube links only -
+                            files need to be re-selected)</span
+                        >
+                    </div>
+                    <button
+                        type="button"
+                        class="text-xs px-2 py-1 bg-blue-100 hover:bg-blue-200 dark:bg-blue-800 dark:hover:bg-blue-700 rounded text-blue-700 dark:text-blue-300"
+                        @click="clearDraft(true)"
+                    >
+                        Clear Draft
+                    </button>
+                </div>
             </div>
-          </div>
+            <div
+                v-if="draftSaved"
+                class="mb-2 p-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded text-sm"
+            >
+                <div
+                    class="flex items-center space-x-2 text-green-700 dark:text-green-300"
+                >
+                    <i class="ri-check-line w-4 h-4"></i>
+                    <span>💾 Draft saved</span>
+                </div>
+            </div>
         </div>
-      </div>
 
-      <!-- Location Section -->
-      <div class="w-full mt-4">
-        <MapPicker
-          v-model:latitude="form.latitude"
-          v-model:longitude="form.longitude"
-          :open-map="isLocationOpen"
-          @address-focus="handleAddressFocus"
-        />
-      </div>
+        <!-- General Upload Error -->
+        <div
+            v-if="singleError"
+            data-single-error
+            class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm"
+        >
+            <div
+                class="flex items-center justify-between text-red-700 dark:text-red-300"
+            >
+                <div class="flex items-center space-x-2">
+                    <i class="ri-error-warning-line w-4 h-4"></i>
+                    <span class="font-medium">Upload Error</span>
+                </div>
+                <div class="flex items-center gap-2">
+                    <button
+                        type="button"
+                        class="text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 rounded text-gray-700 dark:text-gray-200"
+                        @click="handleRetry"
+                    >
+                        Retry
+                    </button>
+                    <button
+                        type="button"
+                        class="text-xs px-2 py-1 bg-red-100 hover:bg-red-200 dark:bg-red-800 dark:hover:bg-red-700 rounded text-red-700 dark:text-red-300"
+                        @click="singleError = null"
+                    >
+                        Dismiss
+                    </button>
+                </div>
+            </div>
+            <div class="mt-2 text-red-700 dark:text-red-300">
+                {{ singleError }}
+            </div>
+        </div>
 
-      <!-- Error Messages -->
-      <div class="mt-4 space-y-2">
-        <p
-          v-if="v$.$errors.length && v$.form.image.required.$invalid"
-          class="text-red-600"
-        >
-          Upload is required without any text on the page.
-        </p>
-        <p
-          v-if="v$.$errors.length && v$.form.content.required.$invalid"
-          class="text-red-600"
-        >
-          Some words are required without an upload.
-        </p>
-        <p
-          v-if="v$.$errors.length && v$.form.video_link.required.$invalid"
-          class="text-red-600"
-        >
-          A link to a video is required without any text or upload.
-        </p>
-      </div>
+        <form enctype="multipart/form-data" @submit.prevent>
+            <!-- Media Type Selection -->
+            <div v-if="isYouTubeEnabled" class="mb-4">
+                <div class="flex flex-wrap gap-2 mb-2">
+                    <Button
+                        :is-active="mediaOption === 'upload'"
+                        class="rounded-none w-24 justify-center text-sm"
+                        @click.prevent="mediaOption = 'upload'"
+                    >
+                        Upload
+                    </Button>
+                    <Button
+                        :is-active="mediaOption === 'link'"
+                        class="rounded-none w-24 justify-center text-sm"
+                        @click.prevent="mediaOption = 'link'"
+                    >
+                        YouTube
+                    </Button>
+                </div>
+            </div>
 
-      <!-- Submit Section -->
-      <div class="flex justify-center mt-5 md:mt-20">
-        <Button
-          type="button"
-          class="w-3/4 flex justify-center py-3"
-          :disabled="isUploading || form.processing"
-          @click.prevent="
-            hasQueuedFiles ? handleUploadAll() : handleFormSubmit()
-          "
-        >
-          <span class="text-xl">
-            {{
-              isUploading
-                ? "Uploading..."
-                : hasQueuedFiles
-                ? "Upload All Files!"
-                : "Create Page!"
-            }}
-          </span>
-        </Button>
-      </div>
-    </form>
-  </div>
+            <!-- Media Type Selection (when YouTube is disabled) -->
+            <div v-else class="mb-4">
+                <div class="flex flex-wrap gap-2 mb-2">
+                    <Button
+                        :is-active="mediaOption === 'upload'"
+                        class="rounded-none w-24 justify-center text-sm"
+                        @click.prevent="mediaOption = 'upload'"
+                    >
+                        Upload
+                    </Button>
+                </div>
+            </div>
+
+            <div class="flex flex-wrap">
+                <!-- Upload Section -->
+                <div v-if="mediaOption === 'upload'" class="w-full mb-2">
+                    <BreezeLabel for="imageInput" value="Media" />
+
+                    <!-- FilePond Uploader -->
+                    <div>
+                        <FilePondUploader
+                            ref="uploaderRef"
+                            :allow-multiple="true"
+                            :accepted-file-types="['image/*', 'video/*']"
+                            max-file-size="512MB"
+                            @queue-update="onPondQueueUpdate"
+                            @processing-start="onPondProcessingStart"
+                            @error="onPondError"
+                            @all-done="onPondAllDone"
+                        />
+                    </div>
+                </div>
+
+                <!-- YouTube Link Section -->
+                <div v-if="mediaOption === 'link'" class="w-full mr-2">
+                    <InputLabel for="media-link" value="YouTube Link" />
+                    <TextInput
+                        id="media-link"
+                        v-model="form.video_link"
+                        class="mt-1 mb-3 block w-full"
+                        placeholder="https://youtube.com/watch?v=..."
+                    />
+                    <InputError
+                        v-if="
+                            v$.$errors.length &&
+                            v$.form.video_link.required.$invalid
+                        "
+                        class="mt-2"
+                        message="A link to a video is required without any text or upload."
+                    />
+
+                    <div v-if="form.video_link" class="w-1/2">
+                        <VideoWrapper
+                            :url="form.video_link"
+                            :controls="false"
+                        />
+                    </div>
+                </div>
+
+                <!-- Content Section -->
+                <div class="w-full">
+                    <BreezeLabel for="content" :value="'Words'" />
+                    <div class="relative">
+                        <Wysiwyg
+                            id="content"
+                            v-model="form.content"
+                            class="mt-1 block w-full"
+                        />
+                        <!-- Auto-save indicator -->
+                        <div
+                            v-if="autoSaveTimeout"
+                            class="absolute top-2 right-2 text-xs text-gray-500 bg-white px-2 py-1 rounded border"
+                        >
+                            ⏱️ Auto-saving in 1s...
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Location Section -->
+            <div class="w-full mt-4">
+                <MapPicker
+                    v-model:latitude="form.latitude"
+                    v-model:longitude="form.longitude"
+                    :open-map="isLocationOpen"
+                    @address-focus="handleAddressFocus"
+                />
+            </div>
+
+            <!-- Error Messages -->
+            <div class="mt-4 space-y-2">
+                <p
+                    v-if="v$.$errors.length && v$.form.images.required.$invalid"
+                    class="text-red-600"
+                >
+                    Upload is required without any text on the page.
+                </p>
+                <p
+                    v-if="
+                        v$.$errors.length && v$.form.content.required.$invalid
+                    "
+                    class="text-red-600"
+                >
+                    Some words are required without an upload.
+                </p>
+                <p
+                    v-if="
+                        v$.$errors.length &&
+                        v$.form.video_link.required.$invalid
+                    "
+                    class="text-red-600"
+                >
+                    A link to a video is required without any text or upload.
+                </p>
+            </div>
+
+            <!-- Submit Section -->
+            <div class="flex justify-center mt-5 md:mt-20">
+                <Button
+                    type="button"
+                    class="w-3/4 flex justify-center py-3"
+                    :disabled="isUploading || form.processing"
+                    @click.prevent="handleFormSubmit()"
+                >
+                    <span class="text-xl">
+                        {{ isUploading ? "Uploading..." : "Create Page!" }}
+                    </span>
+                </Button>
+            </div>
+        </form>
+    </div>
 </template>

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -23,6 +23,17 @@ class PagesTest extends TestCase
     use RefreshDatabase;
     use WithFaker;
 
+    /**
+     * Upload a file through the FilePond temporary-upload endpoint and return the
+     * encrypted server id, mirroring how the frontend uploader works.
+     */
+    private function uploadViaFilepond(UploadedFile $file): string
+    {
+        return $this->post(route('filepond-process'), ['image' => $file])
+            ->assertOk()
+            ->getContent();
+    }
+
     public function test_pictures_are_returned(): void
     {
         $this->actingAs(User::factory()->create());
@@ -272,27 +283,55 @@ class PagesTest extends TestCase
     public function test_page_is_stored_to_book()
     {
         Storage::fake('s3');
+        Storage::fake('local');
 
         $this->actingAs($user = User::factory()->create());
         $user->givePermissionTo('edit pages');
         $book = Book::factory()->create();
 
-        $payload = [
+        $serverId = $this->uploadViaFilepond(UploadedFile::fake()->image('photo1.jpg'));
+        $content = $this->faker->paragraph();
+
+        $response = $this->post(route('pages.store'), [
             'book_id' => $book->id,
-            'content' => $this->faker->paragraph(),
-            'image' => UploadedFile::fake()->image('photo1.jpg'),
-        ];
+            'content' => $content,
+            'images' => [$serverId],
+        ]);
 
-        $response = $this->post(route('pages.store'), $payload);
-
-        $filePath = 'books/'.$book->slug.'/'.pathinfo($payload['image']->hashName(), PATHINFO_FILENAME).'.webp';
-        Storage::disk('s3')->assertExists($filePath);
+        $files = Storage::disk('s3')->files('books/'.$book->slug);
+        $this->assertCount(1, $files);
+        $this->assertStringEndsWith('.webp', $files[0]);
 
         $page = Book::find($book->id)->pages->first();
-        $this->assertSame('/storage'.$page->media_path, Storage::disk('s3')->url($filePath));
-        $this->assertSame($page->content, $payload['content']);
+        $this->assertSame('/storage'.$page->media_path, Storage::disk('s3')->url($files[0]));
+        $this->assertSame($page->content, $content);
 
         $response->assertRedirect(route('books.show', $book));
+    }
+
+    public function test_multiple_uploaded_files_each_create_a_page()
+    {
+        Storage::fake('s3');
+        Storage::fake('local');
+
+        $this->actingAs($user = User::factory()->create());
+        $user->givePermissionTo('edit pages');
+        $book = Book::factory()->create();
+
+        $serverIds = [
+            $this->uploadViaFilepond(UploadedFile::fake()->image('photo1.jpg')),
+            $this->uploadViaFilepond(UploadedFile::fake()->image('photo2.jpg')),
+        ];
+
+        $response = $this->post(route('pages.store'), [
+            'book_id' => $book->id,
+            'content' => $this->faker->paragraph(),
+            'images' => $serverIds,
+        ]);
+
+        $response->assertRedirect(route('books.show', $book));
+        $this->assertCount(2, Book::find($book->id)->pages);
+        $this->assertCount(2, Storage::disk('s3')->files('books/'.$book->slug));
     }
 
     public function test_page_cannot_be_updated_without_permissions()
@@ -1464,20 +1503,21 @@ class PagesTest extends TestCase
     public function test_page_with_image_can_have_location(): void
     {
         Storage::fake('s3');
+        Storage::fake('local');
 
         $this->actingAs($user = User::factory()->create());
         $user->givePermissionTo('edit pages');
         $book = Book::factory()->create();
 
-        $payload = [
+        $serverId = $this->uploadViaFilepond(UploadedFile::fake()->image('photo1.jpg'));
+
+        $response = $this->post(route('pages.store'), [
             'book_id' => $book->id,
             'content' => $this->faker->paragraph(),
-            'image' => UploadedFile::fake()->image('photo1.jpg'),
+            'images' => [$serverId],
             'latitude' => 45.5152,
             'longitude' => -122.6784,
-        ];
-
-        $response = $this->post(route('pages.store'), $payload);
+        ]);
         $response->assertRedirect(route('books.show', $book));
 
         // Note: Since image processing is queued, we can't immediately check the location


### PR DESCRIPTION
## Problem

Uploads in `NewPageForm` intermittently failed on **mobile devices in production** — the message was always "network error" and the in-place **Retry never worked** (only closing/reopening the form and reselecting fixed it). SQS runs the jobs, so this was never server-side processing time; it was the browser → server transfer dropping on flaky cellular connections, plus our own custom logic mishandling the failure.

## Root causes

FilePond is at 4.32.10 — past every bug we suspected. The symptoms came from **our custom code diverging from FilePond's documented patterns**:

- **Hand-rolled single-request `XMLHttpRequest`** — a whole-file POST over flaky cellular dropped with no recovery and no retry.
- **Custom completion detection via integer `status` polling** (`f.status < 5`) treated an errored file (`PROCESSING_ERROR`) as "done", fired `all-done`, and `removeFiles()` **wiped the queue** — so Retry had nothing left to process.

## Changes

Adopt FilePond's documented **chunked, resumable upload** flow backed by [`rahulhaque/laravel-filepond`](https://github.com/rahulhaque/laravel-filepond):

- Files upload to temporary storage in **5 MB chunks**; dropped chunks auto-retry (`chunkRetryDelays`) and resume via `HEAD` instead of restarting. Each request is small, so PHP/proxy body-size and timeout limits no longer apply.
- Completion is driven by FilePond's documented `processfile`/`processfiles` events; errored files stay queued so **Retry resumes** them.
- `PageController::store` resolves submitted server ids via the `Filepond` facade and queues the existing `StoreImage`/`StoreVideo` jobs (pipeline unchanged), then deletes the temps.
- `StorePageRequest` validates `images.*` with `Rule::filepond`, **reusing the existing media rules** (mimetypes + `max:524288`, large files allowed).
- `/filepond` routes gated by `can:edit pages`; `filepond:clear` scheduled daily.

## Testing

- **JS:** 405 passed (incl. updated `NewPageForm` tests for the server-id flow).
- **PHP:** 463 passed, incl. a new multi-file test (`test_multiple_uploaded_files_each_create_a_page`).
- Pint + Prettier clean on touched files.

## Manual verification still recommended

Verified via tests, not a live device. Before relying on it in production, test on a **real phone over cellular** with a large video, and throttle/offline mid-upload in DevTools to confirm chunk resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)