### PR TITLE
Restore maxParallelUploads=1 dropped during chunked FilePond rewrite

### DIFF
--- a/resources/js/Components/FilePondUploader.vue
+++ b/resources/js/Components/FilePondUploader.vue
@@ -93,6 +93,10 @@ const onUpdateFiles = (items) => {
 </script>
 
 <template>
+    <!-- maxParallelUploads=1: each chunk request shares the same PHP session,
+    which serializes on its file lock at write time. With FilePond's default of
+    2 files in flight, that contention surfaces as upload failures on slow
+    mobile connections once more than one file is uploading at once. -->
     <FilePond
         ref="pond"
         v-model="files"
@@ -102,6 +106,7 @@ const onUpdateFiles = (items) => {
         :chunk-uploads="true"
         :chunk-size="5242880"
         :chunk-retry-delays="[500, 1000, 3000]"
+        :max-parallel-uploads="1"
         :max-file-size="maxFileSize"
         :label-idle="labelIdle"
         name="image"

--- a/resources/js/Components/FilePondUploader.vue
+++ b/resources/js/Components/FilePondUploader.vue
@@ -93,10 +93,10 @@ const onUpdateFiles = (items) => {
 </script>
 
 <template>
-    <!-- maxParallelUploads=1: each chunk request shares the same PHP session,
-    which serializes on its file lock at write time. With FilePond's default of
-    2 files in flight, that contention surfaces as upload failures on slow
-    mobile connections once more than one file is uploading at once. -->
+    <!-- chunkForce: FilePond only chunks files larger than chunkSize by default,
+    so most phone photos (under 5MB) would otherwise upload as a single
+    unresumable POST - the same failure mode the chunked/resumable rewrite was
+    meant to fix. Force every file through the chunked path regardless of size. -->
     <FilePond
         ref="pond"
         v-model="files"
@@ -104,9 +104,9 @@ const onUpdateFiles = (items) => {
         :accepted-file-types="acceptedFileTypes"
         :server="server"
         :chunk-uploads="true"
+        :chunk-force="true"
         :chunk-size="5242880"
         :chunk-retry-delays="[500, 1000, 3000]"
-        :max-parallel-uploads="1"
         :max-file-size="maxFileSize"
         :label-idle="labelIdle"
         name="image"


### PR DESCRIPTION
A prior fix (a476a77) serialized FilePond uploads to 1 at a time because
concurrent requests stalled each other. That safeguard was lost when the
uploader was rewritten to use chunked/resumable uploads (f096950), which
restored FilePond's default of 2 parallel files. Each chunk request still
goes through the same PHP session, which serializes via its file lock on
write, so two files uploading at once on a slow mobile connection contend
and surface as upload errors - matching the "half fail when there's a
pool of them" symptom.