### PR TITLE
Revert dashboard caching/defer changes causing load failures

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\ValidationException;
 
 class AdminController extends Controller
@@ -44,10 +43,6 @@ class AdminController extends Controller
         $user = User::where('email', $request->email)->first();
         $user->syncPermissions();
         $user->delete();
-
-        // Invalidate UserController::ownerProps()'s cached User::all() list
-        // (shared by the `authors` and `users` dashboard props).
-        Cache::forget('dashboard-users');
 
         return redirect(route('welcome'));
     }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -9,7 +9,6 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
@@ -57,10 +56,6 @@ class RegisteredUserController extends Controller
         ]);
 
         event(new Registered($user));
-
-        // Invalidate UserController::ownerProps()'s cached User::all() list
-        // (shared by the `authors` and `users` dashboard props).
-        Cache::forget('dashboard-users');
 
         Auth::login($user);
 

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -124,9 +124,6 @@ class BookController extends Controller
     {
         $book = Book::create($request->validated());
 
-        // Invalidate UserController::ownerProps()'s cached "new books this week" list.
-        Cache::forget('dashboard-new-books-this-week');
-
         return redirect(route('books.show', $book))->with('success', __('messages.book.created', ['title' => $book->title]));
     }
 
@@ -238,11 +235,6 @@ class BookController extends Controller
 
         $book->pages()->delete();
         $book->delete();
-
-        // Invalidate dashboard caches that may include this book's pages
-        // (some of which could have been blocked, or shown as recent uploads).
-        Cache::forget('dashboard-blocked-count');
-        Cache::forget('dashboard-recent-uploads');
 
         return redirect(route('books.index'))->with('success', __('messages.book.deleted', ['title' => $book->title]));
     }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -12,7 +12,6 @@ use App\Support\ThemeBooks;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
-use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -97,16 +96,12 @@ class CategoryController extends Controller
     {
         Category::create($request->validated());
 
-        $this->forgetDashboardCategoryCaches();
-
         return redirect(route('welcome'));
     }
 
     public function update(UpdateCategoryRequest $request, Category $category): Application|RedirectResponse|Redirector
     {
         $category->update($request->validated());
-
-        $this->forgetDashboardCategoryCaches();
 
         return redirect(route('welcome'));
     }
@@ -121,18 +116,6 @@ class CategoryController extends Controller
 
         $category->delete();
 
-        $this->forgetDashboardCategoryCaches();
-
         return redirect(route('welcome'));
-    }
-
-    /**
-     * Invalidate the dashboard's cached category lists (UserController::ownerProps)
-     * so category changes show up immediately instead of after the cache TTL.
-     */
-    private function forgetDashboardCategoryCaches(): void
-    {
-        Cache::forget('dashboard-categories');
-        Cache::forget('dashboard-book-categories');
     }
 }

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -596,9 +596,6 @@ class PageController extends Controller
         }
         $page->delete();
 
-        Cache::forget('dashboard-blocked-count');
-        Cache::forget('dashboard-recent-uploads');
-
         return redirect(route('books.show', $page->book))->with('success', __('messages.page.deleted'));
     }
 
@@ -647,8 +644,6 @@ class PageController extends Controller
                     }
                     $page->delete();
                 }
-                Cache::forget('dashboard-blocked-count');
-                Cache::forget('dashboard-recent-uploads');
                 $message = __('messages.page.bulk_deleted', ['count' => count($pages)]);
                 break;
 
@@ -683,8 +678,6 @@ class PageController extends Controller
 
         $page->update(['blocked' => true]);
 
-        Cache::forget('dashboard-blocked-count');
-
         return redirect(route('books.show', $page->book))->with('success', __('messages.page.blocked'));
     }
 
@@ -694,8 +687,6 @@ class PageController extends Controller
         $soundCount = Sound::where('blocked', true)->update(['blocked' => false]);
         $total = $pageCount + $soundCount;
         $message = __('messages.unblocked_all', ['count' => $total]);
-
-        Cache::forget('dashboard-blocked-count');
 
         if ($request->header('X-Inertia')) {
             return redirect()->back()->with('success', $message);

--- a/app/Http/Controllers/SoundsController.php
+++ b/app/Http/Controllers/SoundsController.php
@@ -10,7 +10,6 @@ use App\Models\Sound;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -78,8 +77,6 @@ class SoundsController extends Controller
     {
         $sound->update(['blocked' => true]);
 
-        Cache::forget('dashboard-blocked-count');
-
         return redirect(route('sounds.index'))->with('success', __('messages.sound.blocked'));
     }
 
@@ -92,8 +89,6 @@ class SoundsController extends Controller
         }
 
         $sound->delete();
-
-        Cache::forget('dashboard-blocked-count');
 
         return back()->with('success', __('messages.sound.deleted'));
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -17,20 +17,11 @@ use App\Services\PopularityService;
 use App\Services\UserWeeklyOverviewService;
 use App\Support\WorldClockState;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class UserController extends Controller
 {
-    /**
-     * How long the heavy dashboard/profile queries stay cached. The frontend
-     * re-requests this data on every page visit (see resources/js/Pages/Users/Show.vue
-     * and OwnerPanel.vue), so caching keeps repeat visits cheap without the
-     * data going stale for long.
-     */
-    private const CACHE_TTL_SECONDS = 300;
-
     public function __construct(
         private PopularityService $popularityService,
         private UserWeeklyOverviewService $userWeeklyOverviewService,
@@ -52,65 +43,29 @@ class UserController extends Controller
     {
         $isOwner = auth()->id() === $user->id;
 
-        // Make created_at visible for the profile user
-        $user->makeVisible('created_at');
+        $totalBooksCount = Book::where('author', $user->name)->count();
+        $messagesCount = Message::where('user_id', $user->id)->count();
+        $commentsCount = MessageComment::where('user_id', $user->id)->count();
 
-        $props = [
-            'profileUser' => $user,
-            'isOwner' => $isOwner,
-            'appName' => config('app.name'),
-            'weeklyOverview' => [
-                'text' => $user->weekly_profile_overview,
-                'generatedAt' => $user->weekly_profile_overview_generated_at,
-            ],
-            // These are fetched on-demand by the frontend (via router.reload)
-            // rather than Inertia's automatic deferred-prop fetch, so we use
-            // optional() here: excluded from the initial load like defer(),
-            // but never auto-fetched, which avoids double-fetching.
-            'stats' => Inertia::optional(fn () => Cache::remember(
-                "profile-stats:{$user->id}:".($isOwner ? 'owner' : 'visitor'),
-                self::CACHE_TTL_SECONDS,
-                fn () => $this->profileStats($user, $isOwner)
-            )),
-            // The "authored by this user" message/reply lists are only shown to
-            // visitors (the owner already knows their own content).
-            'recentMessages' => Inertia::optional(fn () => $isOwner ? collect() : Cache::remember(
-                "profile-recent-messages:{$user->id}",
-                self::CACHE_TTL_SECONDS,
-                fn () => Message::where('user_id', $user->id)
-                    ->with(['page', 'user'])
-                    ->orderBy('created_at', 'desc')
-                    ->take(10)
-                    ->get()
-                    ->toArray()
-            )),
-            'recentReplies' => Inertia::optional(fn () => $isOwner ? collect() : Cache::remember(
-                "profile-recent-replies:{$user->id}",
-                self::CACHE_TTL_SECONDS,
-                fn () => MessageComment::where('user_id', $user->id)
-                    ->with(['message.user'])
-                    ->orderBy('created_at', 'desc')
-                    ->take(10)
-                    ->get()
-                    ->toArray()
-            )),
-        ];
+        // Optimize reactions count with a single query using UNION
+        $reactionsGiven = \DB::table('message_reactions')
+            ->where('user_id', $user->id)
+            ->selectRaw('COUNT(*) as count')
+            ->union(
+                \DB::table('comment_reactions')
+                    ->where('user_id', $user->id)
+                    ->selectRaw('COUNT(*) as count')
+            )
+            ->get()
+            ->sum('count');
 
-        if ($isOwner) {
-            $props = array_merge($props, $this->ownerProps($user));
-        }
-
-        return Inertia::render('Users/Show', $props);
-    }
-
-    /**
-     * Stats shown on the profile: cheap counts for the user, plus (visitors only)
-     * their top/recent books, which require the heavier popularity queries.
-     */
-    private function profileStats(User $user, bool $isOwner): array
-    {
+        // The "authored by this user" book/message/reply lists are only shown to
+        // visitors (the owner already knows their own content) — skip fetching
+        // them for the owner's own dashboard to keep the page light.
         $topBooks = collect();
         $recentBooks = collect();
+        $recentMessages = collect();
+        $recentReplies = collect();
 
         if (! $isOwner) {
             $topBooks = $this->popularityService->addPopularityToCollection(
@@ -131,28 +86,48 @@ class UserController extends Controller
                     ->get(),
                 Book::class
             );
+
+            $recentMessages = Message::where('user_id', $user->id)
+                ->with(['page', 'user'])
+                ->orderBy('created_at', 'desc')
+                ->take(10)
+                ->get();
+
+            $recentReplies = MessageComment::where('user_id', $user->id)
+                ->with(['message.user'])
+                ->orderBy('created_at', 'desc')
+                ->take(10)
+                ->get();
         }
 
-        // Optimize reactions count with a single query using UNION
-        $reactionsGiven = \DB::table('message_reactions')
-            ->where('user_id', $user->id)
-            ->selectRaw('COUNT(*) as count')
-            ->union(
-                \DB::table('comment_reactions')
-                    ->where('user_id', $user->id)
-                    ->selectRaw('COUNT(*) as count')
-            )
-            ->get()
-            ->sum('count');
+        // Make created_at visible for the profile user
+        $user->makeVisible('created_at');
 
-        return [
-            'totalBooksCount' => Book::where('author', $user->name)->count(),
-            'topBooks' => $topBooks->toArray(),
-            'recentBooks' => $recentBooks->toArray(),
-            'messagesCount' => Message::where('user_id', $user->id)->count(),
-            'commentsCount' => MessageComment::where('user_id', $user->id)->count(),
-            'reactionsGiven' => $reactionsGiven,
+        $props = [
+            'profileUser' => $user,
+            'isOwner' => $isOwner,
+            'appName' => config('app.name'),
+            'weeklyOverview' => [
+                'text' => $user->weekly_profile_overview,
+                'generatedAt' => $user->weekly_profile_overview_generated_at,
+            ],
+            'stats' => [
+                'totalBooksCount' => $totalBooksCount,
+                'topBooks' => $topBooks,
+                'recentBooks' => $recentBooks,
+                'messagesCount' => $messagesCount,
+                'commentsCount' => $commentsCount,
+                'reactionsGiven' => $reactionsGiven,
+            ],
+            'recentMessages' => $recentMessages,
+            'recentReplies' => $recentReplies,
         ];
+
+        if ($isOwner) {
+            $props = array_merge($props, $this->ownerProps($user));
+        }
+
+        return Inertia::render('Users/Show', $props);
     }
 
     /**
@@ -166,135 +141,86 @@ class UserController extends Controller
         $canAdmin = $user->can('admin');
 
         return [
-            'recentActivity' => Inertia::optional(fn () => Cache::remember(
-                "dashboard-recent-activity:{$user->id}",
-                self::CACHE_TTL_SECONDS,
-                fn () => [
-                    'replies' => MessageComment::query()
-                        ->whereIn('message_id', Message::where('user_id', $user->id)->select('id'))
-                        ->where('user_id', '!=', $user->id)
-                        ->where('created_at', '>=', now()->subDays(7))
-                        ->with(['user', 'message'])
-                        ->latest()
-                        ->take(10)
-                        ->get()
-                        ->toArray(),
-                    'mentions' => $user->notifications()
-                        ->where('type', UserTagged::class)
-                        ->where('created_at', '>=', now()->subDays(7))
-                        ->latest()
-                        ->take(10)
-                        ->get()
-                        ->toArray(),
-                ]
-            )),
-            'newBooksThisWeek' => Inertia::optional(fn () => Cache::remember(
-                'dashboard-new-books-this-week',
-                self::CACHE_TTL_SECONDS,
-                fn () => Book::with('coverImage')
-                    ->where('created_at', '>=', now()->subWeek())
+            'recentActivity' => [
+                'replies' => MessageComment::query()
+                    ->whereIn('message_id', Message::where('user_id', $user->id)->select('id'))
+                    ->where('user_id', '!=', $user->id)
+                    ->where('created_at', '>=', now()->subDays(7))
+                    ->with(['user', 'message'])
                     ->latest()
-                    ->take(8)
-                    ->get()
-                    ->toArray()
-            )),
-            'recentUploads' => Inertia::optional(fn () => Cache::remember(
-                'dashboard-recent-uploads',
-                self::CACHE_TTL_SECONDS,
-                fn () => Page::notBlocked()
-                    ->hasImage()
-                    ->with('book')
+                    ->take(10)
+                    ->get(),
+                'mentions' => $user->notifications()
+                    ->where('type', UserTagged::class)
+                    ->where('created_at', '>=', now()->subDays(7))
                     ->latest()
-                    ->take(12)
-                    ->get()
-                    ->toArray()
-            )),
-            // Shares the "dashboard-users" cache key with the `users` prop below —
-            // both are just User::all(), so whichever resolves first (this one,
-            // eagerly, since the New Book form needs it immediately) fills the
-            // cache for the other instead of querying twice.
-            'authors' => $canEditPages ? Cache::remember(
-                'dashboard-users',
-                self::CACHE_TTL_SECONDS,
-                fn () => User::all()->toArray()
-            ) : [],
+                    ->take(10)
+                    ->get(),
+            ],
+            'newBooksThisWeek' => Book::with('coverImage')
+                ->where('created_at', '>=', now()->subWeek())
+                ->latest()
+                ->take(8)
+                ->get(),
+            'recentUploads' => Page::notBlocked()
+                ->hasImage()
+                ->with('book')
+                ->latest()
+                ->take(12)
+                ->get(),
+            'authors' => $canEditPages ? User::all() : [],
             'newBookCategories' => $canEditPages
-                ? Cache::remember(
-                    'dashboard-book-categories',
-                    self::CACHE_TTL_SECONDS,
-                    fn () => Category::all()->map->only(['id', 'name'])->sortBy('name')->values()->toArray()
-                )
+                ? Category::all()->map->only(['id', 'name'])->sortBy('name')->values()->toArray()
                 : [],
-            'users' => Inertia::optional(fn () => Cache::remember(
-                'dashboard-users',
-                self::CACHE_TTL_SECONDS,
-                fn () => User::all()->toArray()
-            )),
-            'categories' => Inertia::optional(fn () => $canAdmin ? Cache::remember(
-                'dashboard-categories',
-                self::CACHE_TTL_SECONDS,
-                fn () => Category::withCount('books')->get()->toArray()
-            ) : collect()),
-            'blockedCount' => Inertia::optional(fn () => $canEditPages ? Cache::remember(
-                'dashboard-blocked-count',
-                self::CACHE_TTL_SECONDS,
-                fn () => Page::where('blocked', true)->count() + Sound::where('blocked', true)->count()
-            ) : 0),
-            'adminSettings' => Inertia::optional(fn () => $canAdmin ? $this->settingsController->index() : []),
-            'siteStats' => Inertia::optional(fn () => Cache::remember(
-                'dashboard-site-stats',
-                self::CACHE_TTL_SECONDS,
-                fn () => [
-                    // totalCount() reuses the same warmed read-count list that
-                    // addPopularityToCollection() below needs, avoiding a
-                    // redundant COUNT(*) query for the same table.
-                    'numberOfBooks' => $this->popularityService->totalCount(Book::class),
-                    'numberOfPages' => Page::count(),
-                    'numberOfSongs' => $this->popularityService->totalCount(Song::class),
-                    'numberOfYouTubeVideos' => Page::whereNotNull('video_link')->count(),
-                    'numberOfVideos' => Page::where('media_path', 'like', '%.mp4')->count(),
-                    'numberOfImages' => Page::where('media_path', 'like', '%.webp')
-                        ->where('media_path', 'not like', '%snapshot%')
-                        ->count(),
-                    'numberOfScreenshots' => Page::where('media_path', 'like', '%snapshot%')->count(),
-                    'mostReadBooks' => $this->popularityService->addPopularityToCollection(
-                        Book::query()
-                            ->with('coverImage')
-                            ->orderBy('read_count', 'desc')
-                            ->orderBy('created_at')
-                            ->take(5)
-                            ->get(),
-                        Book::class
-                    )->toArray(),
-                    'mostReadSongs' => $this->popularityService->addPopularityToCollection(
-                        Song::query()
-                            ->orderBy('read_count', 'desc')
-                            ->take(5)
-                            ->get(),
-                        Song::class
-                    )->toArray(),
-                    'leastPages' => Book::with('coverImage')
-                        ->withCount('pages')
-                        ->orderBy('pages_count')
+            'adminUsers' => User::permission('admin')->get(['name']),
+            'users' => User::all(),
+            'categories' => $canAdmin ? Category::withCount('books')->get() : [],
+            'blockedCount' => $canEditPages
+                ? Page::where('blocked', true)->count() + Sound::where('blocked', true)->count()
+                : 0,
+            'siteStats' => Inertia::defer(fn () => [
+                'numberOfBooks' => Book::count(),
+                'numberOfPages' => Page::count(),
+                'numberOfSongs' => Song::count(),
+                'numberOfYouTubeVideos' => Page::whereNotNull('video_link')->count(),
+                'numberOfVideos' => Page::where('media_path', 'like', '%.mp4')->count(),
+                'numberOfImages' => Page::where('media_path', 'like', '%.webp')
+                    ->where('media_path', 'not like', '%snapshot%')
+                    ->count(),
+                'numberOfScreenshots' => Page::where('media_path', 'like', '%snapshot%')->count(),
+                'mostReadBooks' => $this->popularityService->addPopularityToCollection(
+                    Book::query()
+                        ->with('coverImage')
+                        ->orderBy('read_count', 'desc')
                         ->orderBy('created_at')
-                        ->first()
-                        ?->toArray(),
-                    'mostPages' => Book::with('coverImage')
-                        ->withCount('pages')
-                        ->orderBy('pages_count', 'desc')
-                        ->orderBy('created_at')
-                        ->first()
-                        ?->toArray(),
-                ]
-            )),
+                        ->take(5)
+                        ->get(),
+                    Book::class
+                )->toArray(),
+                'mostReadSongs' => $this->popularityService->addPopularityToCollection(
+                    Song::query()
+                        ->orderBy('read_count', 'desc')
+                        ->take(5)
+                        ->get(),
+                    Song::class
+                )->toArray(),
+                'leastPages' => Book::with('coverImage')
+                    ->withCount('pages')
+                    ->orderBy('pages_count')
+                    ->orderBy('created_at')
+                    ->first()
+                    ?->toArray(),
+                'mostPages' => Book::with('coverImage')
+                    ->withCount('pages')
+                    ->orderBy('pages_count', 'desc')
+                    ->orderBy('created_at')
+                    ->first()
+                    ?->toArray(),
+            ]),
+            'adminSettings' => $canAdmin ? $this->settingsController->index() : [],
             'defaultCities' => config('world_clock.default_cities'),
             'maxCities' => config('world_clock.max_cities'),
-            'timezoneLabels' => Cache::remember(
-                'dashboard-timezone-labels',
-                self::CACHE_TTL_SECONDS,
-                fn () => TimezoneLabel::pluck('label', 'timezone')->toArray()
-            ),
-            // Not cached: includes server_now/timer state that must stay fresh on every request.
+            'timezoneLabels' => TimezoneLabel::pluck('label', 'timezone'),
             'worldClock' => WorldClockState::payload(WorldClockSetting::instance()),
         ];
     }

--- a/app/Jobs/StoreImage.php
+++ b/app/Jobs/StoreImage.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Encoders\WebpEncoder;
@@ -108,9 +107,6 @@ class StoreImage implements ShouldQueue
                     $this->book->update(['cover_page' => $page->id]);
                 }
             }
-
-            // Invalidate UserController::ownerProps()'s cached "recent uploads" list.
-            Cache::forget('dashboard-recent-uploads');
 
             // Delete old media/poster if provided (post-success)
             try {

--- a/app/Jobs/StoreVideo.php
+++ b/app/Jobs/StoreVideo.php
@@ -12,7 +12,6 @@ use Illuminate\Http\File;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -407,9 +406,6 @@ class StoreVideo implements ShouldQueue
                         }
                     }
                 });
-
-                // Invalidate UserController::ownerProps()'s cached "recent uploads" list.
-                Cache::forget('dashboard-recent-uploads');
 
                 // After successful DB update, delete any old media/poster
                 try {

--- a/resources/js/Pages/Users/Partials/OwnerPanel.vue
+++ b/resources/js/Pages/Users/Partials/OwnerPanel.vue
@@ -27,164 +27,116 @@ const unlockingBlockedPages = ref(false);
 const settingsAccordionOpen = ref(false);
 
 const props = defineProps({
-    users: { type: Array, default: () => [] },
-    siteStats: { type: [Object, Function], default: () => ({}) },
-    categories: { type: Array, default: () => [] },
-    adminSettings: { type: Array, default: () => [] },
-    blockedCount: { type: Number, default: 0 },
-    defaultCities: { type: Array, default: () => [] },
-    maxCities: { type: Number, default: 6 },
-    timezoneLabels: { type: Object, default: () => ({}) },
-    worldClock: { type: Object, default: null },
+  adminUsers: { type: Array, default: () => [] },
+  users: { type: Array, default: () => [] },
+  siteStats: { type: [Object, Function], default: () => ({}) },
+  categories: { type: Array, default: () => [] },
+  adminSettings: { type: Array, default: () => [] },
+  blockedCount: { type: Number, default: 0 },
+  defaultCities: { type: Array, default: () => [] },
+  maxCities: { type: Number, default: 6 },
+  timezoneLabels: { type: Object, default: () => ({}) },
+  worldClock: { type: Object, default: null },
 });
 
-// users/siteStats/categories/adminSettings/blockedCount are deferred data
-// fetched by the parent Show.vue's onMounted router.reload (batched with its
-// own deferred props into a single request) - not fetched from here.
-
 const speakBlockedCount = () => {
-    speak(t("dashboard.blocked_pages_count", { count: props.blockedCount }));
+  speak(t("dashboard.blocked_pages_count", { count: props.blockedCount }));
 };
 
 const unblockAllPages = async () => {
-    if (unlockingBlockedPages.value) return;
-    unlockingBlockedPages.value = true;
-    try {
-        const { data } = await axios.post(
-            route("pages.unblock-all"),
-            {},
-            { headers: { Accept: "application/json" } }
-        );
-        setFlashMessage("success", data.message);
-        router.reload({
-            only: ["blockedCount"],
-            preserveScroll: true,
-            async: true,
-        });
-    } finally {
-        unlockingBlockedPages.value = false;
-    }
+  if (unlockingBlockedPages.value) return;
+  unlockingBlockedPages.value = true;
+  try {
+    const { data } = await axios.post(
+      route("pages.unblock-all"),
+      {},
+      { headers: { Accept: "application/json" } }
+    );
+    setFlashMessage("success", data.message);
+    router.reload({ only: ["blockedCount"], preserveScroll: true, async: true });
+  } finally {
+    unlockingBlockedPages.value = false;
+  }
 };
 </script>
 
 <template>
+  <div class="space-y-6">
     <div class="space-y-6">
-        <div class="space-y-6">
-            <Accordion title="Avatar">
-                <AvatarSelectionForm />
-            </Accordion>
-            <Accordion title="Voice Settings">
-                <VoiceSettingsForm />
-            </Accordion>
-            <Accordion title="Notification Settings">
-                <NotificationToggle />
-            </Accordion>
-            <Accordion title="Clocks">
-                <ClocksSection
-                    :default-cities="defaultCities"
-                    :max-cities="maxCities"
-                    :timezone-labels="timezoneLabels"
-                    :world-clock="worldClock"
-                />
-            </Accordion>
-            <Accordion title="Users">
-                <UsersForm :users="users" />
-            </Accordion>
-            <Accordion title="Site Statistics">
-                <!-- Populated by Show.vue's onMounted reload, which must keep
-                     "siteStats" in its `only` list or this never resolves. -->
-                <Deferred data="siteStats">
-                    <template #fallback>
-                        <div
-                            class="space-y-4 py-2"
-                            role="status"
-                            aria-live="polite"
-                            aria-label="Loading statistics"
-                        >
-                            <div
-                                class="flex items-center gap-3 text-gray-900 dark:text-gray-100"
-                            >
-                                <i
-                                    class="ri-loader-4-line text-2xl animate-spin"
-                                ></i>
-                                <span class="font-medium"
-                                    >Loading statistics...</span
-                                >
-                            </div>
-                            <div class="space-y-2">
-                                <div
-                                    class="h-3 w-3/4 rounded bg-gray-200 dark:bg-gray-700 animate-pulse"
-                                ></div>
-                                <div
-                                    class="h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-700 animate-pulse"
-                                ></div>
-                                <div
-                                    class="h-3 w-1/2 rounded bg-gray-200 dark:bg-gray-700 animate-pulse"
-                                ></div>
-                            </div>
-                        </div>
-                    </template>
-                    <StatsCard :stats="siteStats" />
-                </Deferred>
-            </Accordion>
-        </div>
-
-        <div v-if="canEditPages || canAdmin" class="space-y-6">
-            <h3 class="font-heading text-2xl text-theme-title px-1">
-                Administration
-            </h3>
-            <Accordion v-if="canEditPages" :title="t('dashboard.unblock')">
-                <div class="space-y-3">
-                    <div class="flex items-center gap-2">
-                        <p class="text-gray-900 dark:text-gray-100">
-                            {{
-                                t("dashboard.blocked_pages_count", {
-                                    count: blockedCount,
-                                })
-                            }}
-                        </p>
-                        <SpeakButton
-                            :disabled="speaking"
-                            aria-label="Speak blocked pages count"
-                            icon-class="ri-speak-fill text-lg"
-                            @click="speakBlockedCount"
-                        />
-                    </div>
-                    <div class="flex items-center gap-2">
-                        <Button
-                            type="button"
-                            :disabled="
-                                unlockingBlockedPages || blockedCount === 0
-                            "
-                            :aria-label="
-                                t('dashboard.unlock_all_blocked_pages_aria')
-                            "
-                            @click="unblockAllPages"
-                        >
-                            <i
-                                v-if="unlockingBlockedPages"
-                                class="ri-loader-line text-xl animate-spin"
-                            ></i>
-                            <span v-else>{{
-                                t("dashboard.unlock_all_blocked_pages")
-                            }}</span>
-                        </Button>
-                    </div>
-                </div>
-            </Accordion>
-            <Accordion v-if="canAdmin" title="Categories">
-                <CategoriesForm :categories="categories" />
-            </Accordion>
-            <Accordion
-                v-if="canAdmin"
-                v-model="settingsAccordionOpen"
-                title="Site Settings"
-            >
-                <SettingsForm
-                    :settings="adminSettings"
-                    @submitted="settingsAccordionOpen = false"
-                />
-            </Accordion>
-        </div>
+      <Accordion title="Avatar">
+        <AvatarSelectionForm />
+      </Accordion>
+      <Accordion title="Voice Settings">
+        <VoiceSettingsForm />
+      </Accordion>
+      <Accordion title="Notification Settings">
+        <NotificationToggle />
+      </Accordion>
+      <Accordion title="Clocks">
+        <ClocksSection
+          :default-cities="defaultCities"
+          :max-cities="maxCities"
+          :timezone-labels="timezoneLabels"
+          :world-clock="worldClock"
+        />
+      </Accordion>
+      <Accordion title="Users">
+        <UsersForm :users="users" />
+      </Accordion>
+      <Accordion title="Site Statistics">
+        <Deferred data="siteStats">
+          <template #fallback>
+            <div class="space-y-4 py-2" role="status" aria-live="polite" aria-label="Loading statistics">
+              <div class="flex items-center gap-3 text-gray-900 dark:text-gray-100">
+                <i class="ri-loader-4-line text-2xl animate-spin"></i>
+                <span class="font-medium">Loading statistics...</span>
+              </div>
+              <div class="space-y-2">
+                <div class="h-3 w-3/4 rounded bg-gray-200 dark:bg-gray-700 animate-pulse"></div>
+                <div class="h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-700 animate-pulse"></div>
+                <div class="h-3 w-1/2 rounded bg-gray-200 dark:bg-gray-700 animate-pulse"></div>
+              </div>
+            </div>
+          </template>
+          <StatsCard :stats="siteStats" />
+        </Deferred>
+      </Accordion>
     </div>
+
+    <div v-if="canEditPages || canAdmin" class="space-y-6">
+      <h3 class="font-heading text-2xl text-theme-title px-1">Administration</h3>
+      <Accordion v-if="canEditPages" :title="t('dashboard.unblock')">
+        <div class="space-y-3">
+          <div class="flex items-center gap-2">
+            <p class="text-gray-900 dark:text-gray-100">
+              {{ t("dashboard.blocked_pages_count", { count: blockedCount }) }}
+            </p>
+            <SpeakButton
+              :disabled="speaking"
+              aria-label="Speak blocked pages count"
+              icon-class="ri-speak-fill text-lg"
+              @click="speakBlockedCount"
+            />
+          </div>
+          <div class="flex items-center gap-2">
+            <Button
+              type="button"
+              :disabled="unlockingBlockedPages || blockedCount === 0"
+              :aria-label="t('dashboard.unlock_all_blocked_pages_aria')"
+              @click="unblockAllPages"
+            >
+              <i v-if="unlockingBlockedPages" class="ri-loader-line text-xl animate-spin"></i>
+              <span v-else>{{ t("dashboard.unlock_all_blocked_pages") }}</span>
+            </Button>
+          </div>
+        </div>
+      </Accordion>
+      <Accordion v-if="canAdmin" title="Categories">
+        <CategoriesForm :categories="categories" />
+      </Accordion>
+      <Accordion v-if="canAdmin" v-model="settingsAccordionOpen" title="Site Settings">
+        <SettingsForm :settings="adminSettings" @submitted="settingsAccordionOpen = false" />
+      </Accordion>
+    </div>
+  </div>
 </template>

--- a/resources/js/Pages/Users/Show.test.js
+++ b/resources/js/Pages/Users/Show.test.js
@@ -13,14 +13,13 @@ global.route = (name, params) => {
 };
 
 const mockRouterPost = vi.hoisted(() => vi.fn());
-const mockRouterReload = vi.hoisted(() => vi.fn());
 const mockCanAdmin = vi.hoisted(() => vi.fn(() => false));
 const mockCanEditPages = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("@inertiajs/vue3", () => ({
     Head: { name: "Head", template: "<head><slot /></head>", props: ["title"] },
     Link: { name: "Link", template: "<a><slot /></a>", props: ["href"] },
-    router: { post: mockRouterPost, reload: mockRouterReload },
+    router: { post: mockRouterPost },
 }));
 
 vi.mock("@/composables/permissions", () => ({
@@ -455,12 +454,8 @@ describe("UserShow", () => {
             expect(wrapper.text()).toContain("profile.welcome_header");
             expect(wrapper.text()).toContain("profile.welcome_with_name");
             expect(wrapper.text()).not.toContain("profile.user_top_books");
-            expect(wrapper.text()).not.toContain(
-                "profile.user_recently_created"
-            );
-            expect(wrapper.text()).not.toContain(
-                "profile.user_latest_messages"
-            );
+            expect(wrapper.text()).not.toContain("profile.user_recently_created");
+            expect(wrapper.text()).not.toContain("profile.user_latest_messages");
             expect(wrapper.text()).not.toContain("profile.user_latest_replies");
         });
 
@@ -522,9 +517,7 @@ describe("UserShow", () => {
             expect(wrapper.text()).toContain("Brand New Book");
             expect(wrapper.text()).toContain("profile.recent_uploads");
             expect(wrapper.text()).toContain("Some Book");
-            expect(wrapper.findComponent({ name: "OwnerPanel" }).exists()).toBe(
-                true
-            );
+            expect(wrapper.findComponent({ name: "OwnerPanel" }).exists()).toBe(true);
         });
 
         it("does not render OwnerPanel or owner-only sections for visitors", () => {
@@ -539,9 +532,7 @@ describe("UserShow", () => {
                 global: { stubs: ownerStubs },
             });
 
-            expect(wrapper.findComponent({ name: "OwnerPanel" }).exists()).toBe(
-                false
-            );
+            expect(wrapper.findComponent({ name: "OwnerPanel" }).exists()).toBe(false);
             expect(wrapper.text()).not.toContain("profile.replies_to_you");
             expect(wrapper.text()).not.toContain("profile.messages_to_you");
             expect(wrapper.text()).not.toContain("profile.new_books_this_week");
@@ -563,9 +554,7 @@ describe("UserShow", () => {
             });
 
             expect(wrapper.text()).toContain("dashboard.new_book");
-            expect(
-                wrapper.findComponent({ name: "NewBookForm" }).exists()
-            ).toBe(false);
+            expect(wrapper.findComponent({ name: "NewBookForm" }).exists()).toBe(false);
         });
 
         it("hides the new-book CTA when the owner cannot edit pages", () => {

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -48,14 +48,7 @@ const props = defineProps({
     },
     stats: {
         type: Object,
-        default: () => ({
-            totalBooksCount: 0,
-            topBooks: [],
-            recentBooks: [],
-            messagesCount: 0,
-            commentsCount: 0,
-            reactionsGiven: 0,
-        }),
+        required: true,
     },
     recentMessages: {
         type: Array,
@@ -82,6 +75,10 @@ const props = defineProps({
         default: () => [],
     },
     newBookCategories: {
+        type: Array,
+        default: () => [],
+    },
+    adminUsers: {
         type: Array,
         default: () => [],
     },
@@ -138,47 +135,9 @@ const scheduleTootFoodsRise = (minDelay = 8000, maxDelay = 22000) => {
     }, delay);
 };
 
-// These props arrive as deferred data from the backend. Rather than relying
-// on Inertia's automatic post-mount deferred fetch (which hasn't reliably
-// fired in production), request them explicitly once the page mounts.
-// Batched into a single reload (rather than one per prop, and rather than a
-// separate reload from OwnerPanel.vue) since every request re-runs the
-// controller's eager props too - fewer requests means less redundant work
-// server-side, not just fewer round trips. OwnerPanel.vue's siteStats
-// <Deferred> depends on "siteStats" staying in this list.
 onMounted(() => {
-    const reloadOptions = {
-        preserveScroll: true,
-        preserveState: true,
-        showProgress: false,
-    };
-
     if (props.isOwner) {
         scheduleTootFoodsRise(2000, 4000);
-
-        const only = [
-            "stats",
-            "recentActivity",
-            "newBooksThisWeek",
-            "recentUploads",
-            "siteStats",
-            "users",
-        ];
-
-        if (canEditPages.value) {
-            only.push("blockedCount");
-        }
-
-        if (canAdmin.value) {
-            only.push("categories", "adminSettings");
-        }
-
-        router.reload({ only, ...reloadOptions });
-    } else {
-        router.reload({
-            only: ["stats", "recentMessages", "recentReplies"],
-            ...reloadOptions,
-        });
     }
 });
 
@@ -208,7 +167,7 @@ const regenerateWeeklyOverview = () => {
             onFinish: () => {
                 regenerating.value = false;
             },
-        }
+        },
     );
 };
 
@@ -293,18 +252,14 @@ const hasMessagesToYou = computed(() => messagesToYou.value.length > 0);
 
 const speakRepliesToYou = () => {
     const texts = repliesToYou.value.map(
-        (item) =>
-            `${item.actorName} ${t("profile.activity_reply")}: ${item.preview}`
+        (item) => `${item.actorName} ${t("profile.activity_reply")}: ${item.preview}`,
     );
     speak(t("profile.speak_replies_to_you", { list: texts.join(". ") }));
 };
 
 const speakMessagesToYou = () => {
     const texts = messagesToYou.value.map(
-        (item) =>
-            `${item.actorName} ${t("profile.activity_mention")}: ${
-                item.preview
-            }`
+        (item) => `${item.actorName} ${t("profile.activity_mention")}: ${item.preview}`,
     );
     speak(t("profile.speak_messages_to_you", { list: texts.join(". ") }));
 };
@@ -319,10 +274,7 @@ const speakRecentUploads = () => {
 
 const speakUserSummary = () => {
     const greeting = props.isOwner
-        ? t("profile.welcome_with_name", {
-              app_name: props.appName,
-              name: props.profileUser.name,
-          })
+        ? t("profile.welcome_with_name", { app_name: props.appName, name: props.profileUser.name })
         : `${props.profileUser.name}.`;
 
     if (props.weeklyOverview?.text) {
@@ -331,21 +283,13 @@ const speakUserSummary = () => {
     }
 
     const booksWord =
-        props.stats.totalBooksCount === 1
-            ? t("general.book")
-            : t("general.books");
+        props.stats.totalBooksCount === 1 ? t("general.book") : t("general.books");
     const messagesWord =
-        props.stats.messagesCount === 1
-            ? t("general.message")
-            : t("general.messages");
+        props.stats.messagesCount === 1 ? t("general.message") : t("general.messages");
     const commentsWord =
-        props.stats.commentsCount === 1
-            ? t("general.comment")
-            : t("general.comments");
+        props.stats.commentsCount === 1 ? t("general.comment") : t("general.comments");
     const reactionsWord =
-        props.stats.reactionsGiven === 1
-            ? t("general.reaction")
-            : t("general.reactions");
+        props.stats.reactionsGiven === 1 ? t("general.reaction") : t("general.reactions");
 
     const summary = [
         greeting,
@@ -386,14 +330,8 @@ const speakUserSummary = () => {
                 >
                     <i class="ri-arrow-left-line text-xl"></i>
                 </Link>
-                <h2
-                    class="font-heading text-2xl text-theme-title leading-tight"
-                >
-                    {{
-                        isOwner
-                            ? t("profile.welcome_header", { app_name: appName })
-                            : profileUser.name
-                    }}
+                <h2 class="font-heading text-2xl text-theme-title leading-tight">
+                    {{ isOwner ? t("profile.welcome_header", { app_name: appName }) : profileUser.name }}
                 </h2>
             </div>
         </template>
@@ -405,9 +343,7 @@ const speakUserSummary = () => {
                     v-if="isOwner && canEditPages"
                     class="bg-teal-700 dark:bg-teal-800 overflow-hidden shadow-sm rounded-lg mb-6 p-6"
                 >
-                    <div
-                        class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
-                    >
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                         <div>
                             <h3 class="font-heading text-xl text-amber-400">
                                 {{ t("dashboard.new_book") }}
@@ -447,31 +383,17 @@ const speakUserSummary = () => {
                     class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg mb-6"
                 >
                     <div class="p-6">
-                        <div
-                            class="flex flex-col sm:flex-row sm:items-start gap-4 sm:gap-6"
-                        >
-                            <Avatar
-                                :user="profileUser"
-                                size="xl"
-                                class="flex-shrink-0"
-                            />
+                        <div class="flex flex-col sm:flex-row sm:items-start gap-4 sm:gap-6">
+                            <Avatar :user="profileUser" size="xl" class="flex-shrink-0" />
                             <div class="flex-1 min-w-0">
-                                <div
-                                    class="flex items-start justify-between gap-3"
-                                >
+                                <div class="flex items-start justify-between gap-3">
                                     <div class="min-w-0">
                                         <h1
                                             class="font-heading text-3xl text-gray-900 dark:text-theme-title mb-1 truncate"
                                         >
                                             {{
                                                 isOwner
-                                                    ? t(
-                                                          "profile.welcome_with_name",
-                                                          {
-                                                              app_name: appName,
-                                                              name: profileUser.name,
-                                                          }
-                                                      )
+                                                    ? t("profile.welcome_with_name", { app_name: appName, name: profileUser.name })
                                                     : profileUser.name
                                             }}
                                         </h1>
@@ -483,13 +405,8 @@ const speakUserSummary = () => {
                                         <div
                                             class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
                                         >
-                                            <i
-                                                class="ri-calendar-line flex-shrink-0"
-                                            ></i>
-                                            <span
-                                                >Member since
-                                                {{ memberSince }}</span
-                                            >
+                                            <i class="ri-calendar-line flex-shrink-0"></i>
+                                            <span>Member since {{ memberSince }}</span>
                                         </div>
                                     </div>
                                     <SpeakButton
@@ -505,9 +422,7 @@ const speakUserSummary = () => {
                                     class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700"
                                 >
                                     <div v-if="weeklyOverview?.text">
-                                        <p
-                                            class="text-xs text-gray-600 dark:text-gray-400 mb-1.5"
-                                        >
+                                        <p class="text-xs text-gray-600 dark:text-gray-400 mb-1.5">
                                             Weekly AI story
                                         </p>
                                         <p
@@ -516,13 +431,14 @@ const speakUserSummary = () => {
                                             {{ weeklyOverview.text }}
                                         </p>
                                     </div>
-                                    <div class="flex items-center gap-3 mt-2">
+                                    <div
+                                        class="flex items-center gap-3 mt-2"
+                                    >
                                         <p
                                             v-if="weeklyOverviewGeneratedAt"
                                             class="text-xs text-gray-600 dark:text-gray-400"
                                         >
-                                            Updated
-                                            {{ weeklyOverviewGeneratedAt }}
+                                            Updated {{ weeklyOverviewGeneratedAt }}
                                         </p>
                                         <button
                                             v-if="canAdmin"
@@ -534,10 +450,7 @@ const speakUserSummary = () => {
                                         >
                                             <i
                                                 class="ri-refresh-line"
-                                                :class="{
-                                                    'animate-spin':
-                                                        regenerating,
-                                                }"
+                                                :class="{ 'animate-spin': regenerating }"
                                             ></i>
                                             {{
                                                 regenerating
@@ -553,10 +466,7 @@ const speakUserSummary = () => {
                 </div>
 
                 <!-- Book Stats (books authored by this user - visitors only) -->
-                <div
-                    v-if="!isOwner"
-                    class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6"
-                >
+                <div v-if="!isOwner" class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
                     <!-- Top Books by Popularity -->
                     <div
                         v-if="stats.topBooks.length > 0"
@@ -568,18 +478,9 @@ const speakUserSummary = () => {
                                     <h3
                                         class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
                                     >
-                                        <i
-                                            class="ri-fire-line text-teal-700 dark:text-teal-400"
-                                        ></i>
-                                        {{
-                                            t("profile.user_top_books", {
-                                                name: profileUser.name,
-                                            })
-                                        }}
-                                        <span
-                                            class="font-normal text-gray-600 dark:text-gray-400"
-                                            >by popularity</span
-                                        >
+                                        <i class="ri-fire-line text-teal-700 dark:text-teal-400"></i>
+                                        {{ t("profile.user_top_books", { name: profileUser.name }) }}
+                                        <span class="font-normal text-gray-600 dark:text-gray-400">by popularity</span>
                                     </h3>
                                 </div>
                                 <SpeakButton
@@ -597,11 +498,7 @@ const speakUserSummary = () => {
                                     icon="ri-book-line"
                                     icon-color="text-teal-700 dark:text-teal-400"
                                     :label="book.title"
-                                    :href="
-                                        route('books.show', {
-                                            book: book?.slug,
-                                        })
-                                    "
+                                    :href="route('books.show', { book: book?.slug })"
                                     :cover-image="book.cover_image?.media_path"
                                 />
                             </div>
@@ -619,18 +516,10 @@ const speakUserSummary = () => {
                                     <h3
                                         class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
                                     >
-                                        <i
-                                            class="ri-book-2-line text-amber-500 dark:text-amber-400"
-                                        ></i>
-                                        {{
-                                            t("profile.user_recently_created", {
-                                                name: profileUser.name,
-                                            })
-                                        }}
+                                        <i class="ri-book-2-line text-amber-500 dark:text-amber-400"></i>
+                                        {{ t("profile.user_recently_created", { name: profileUser.name }) }}
                                     </h3>
-                                    <p
-                                        class="text-sm text-gray-600 dark:text-gray-400 mt-0.5"
-                                    >
+                                    <p class="text-sm text-gray-600 dark:text-gray-400 mt-0.5">
                                         {{ stats.totalBooksCount }} books total
                                     </p>
                                 </div>
@@ -653,11 +542,7 @@ const speakUserSummary = () => {
                                         book.popularity_percentage ?? 0
                                     }%`"
                                     :subtitle="`${formatDate(book.created_at)}`"
-                                    :href="
-                                        route('books.show', {
-                                            book: book?.slug,
-                                        })
-                                    "
+                                    :href="route('books.show', { book: book?.slug })"
                                     :cover-image="book.cover_image?.media_path"
                                 />
                             </div>
@@ -672,9 +557,7 @@ const speakUserSummary = () => {
                             <h3
                                 class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2 mb-4"
                             >
-                                <i
-                                    class="ri-bar-chart-line text-teal-700 dark:text-teal-400"
-                                ></i>
+                                <i class="ri-bar-chart-line text-teal-700 dark:text-teal-400"></i>
                                 Activity
                             </h3>
                             <div class="space-y-3">
@@ -689,12 +572,7 @@ const speakUserSummary = () => {
                                             :disabled="speaking"
                                             aria-label="Speak total books"
                                             icon-class="ri-speak-fill text-lg"
-                                            @click="
-                                                speakActivityStat(
-                                                    'profile.stat_total_books',
-                                                    stats.totalBooksCount
-                                                )
-                                            "
+                                            @click="speakActivityStat('profile.stat_total_books', stats.totalBooksCount)"
                                         />
                                     </template>
                                 </StatCard>
@@ -709,12 +587,7 @@ const speakUserSummary = () => {
                                             :disabled="speaking"
                                             aria-label="Speak comments posted"
                                             icon-class="ri-speak-fill text-lg"
-                                            @click="
-                                                speakActivityStat(
-                                                    'profile.stat_comments',
-                                                    stats.commentsCount
-                                                )
-                                            "
+                                            @click="speakActivityStat('profile.stat_comments', stats.commentsCount)"
                                         />
                                     </template>
                                 </StatCard>
@@ -729,12 +602,7 @@ const speakUserSummary = () => {
                                             :disabled="speaking"
                                             aria-label="Speak reactions given"
                                             icon-class="ri-speak-fill text-lg"
-                                            @click="
-                                                speakActivityStat(
-                                                    'profile.stat_reactions',
-                                                    stats.reactionsGiven
-                                                )
-                                            "
+                                            @click="speakActivityStat('profile.stat_reactions', stats.reactionsGiven)"
                                         />
                                     </template>
                                 </StatCard>
@@ -745,10 +613,7 @@ const speakUserSummary = () => {
 
                 <!-- Recent Messages / Recent Replies posted by this user (visitors only) -->
                 <div
-                    v-if="
-                        !isOwner &&
-                        (recentMessages.length > 0 || recentReplies.length > 0)
-                    "
+                    v-if="!isOwner && (recentMessages.length > 0 || recentReplies.length > 0)"
                     class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6"
                 >
                     <div
@@ -760,38 +625,22 @@ const speakUserSummary = () => {
                                 <h3
                                     class="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
                                 >
-                                    <i
-                                        class="ri-message-3-line text-teal-700 dark:text-teal-400"
-                                    ></i>
-                                    {{
-                                        t("profile.user_latest_messages", {
-                                            name: profileUser.name,
-                                        })
-                                    }}
+                                    <i class="ri-message-3-line text-teal-700 dark:text-teal-400"></i>
+                                    {{ t("profile.user_latest_messages", { name: profileUser.name }) }}
                                 </h3>
                                 <div class="flex items-center gap-2">
-                                    <span
-                                        class="text-sm text-gray-600 dark:text-gray-400"
-                                    >
+                                    <span class="text-sm text-gray-600 dark:text-gray-400">
                                         {{ stats.messagesCount }} total
                                     </span>
                                     <SpeakButton
                                         :disabled="speaking"
                                         aria-label="Speak messages count"
                                         icon-class="ri-speak-fill text-lg"
-                                        @click="
-                                            speakActivityStat(
-                                                'profile.stat_messages',
-                                                stats.messagesCount
-                                            )
-                                        "
+                                        @click="speakActivityStat('profile.stat_messages', stats.messagesCount)"
                                     />
                                 </div>
                             </div>
-                            <MessageTimeline
-                                :messages="recentMessages"
-                                read-only
-                            />
+                            <MessageTimeline :messages="recentMessages" read-only />
                         </div>
                     </div>
 
@@ -804,31 +653,18 @@ const speakUserSummary = () => {
                                 <h3
                                     class="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
                                 >
-                                    <i
-                                        class="ri-reply-line text-teal-700 dark:text-teal-400"
-                                    ></i>
-                                    {{
-                                        t("profile.user_latest_replies", {
-                                            name: profileUser.name,
-                                        })
-                                    }}
+                                    <i class="ri-reply-line text-teal-700 dark:text-teal-400"></i>
+                                    {{ t("profile.user_latest_replies", { name: profileUser.name }) }}
                                 </h3>
                                 <div class="flex items-center gap-2">
-                                    <span
-                                        class="text-sm text-gray-600 dark:text-gray-400"
-                                    >
+                                    <span class="text-sm text-gray-600 dark:text-gray-400">
                                         {{ stats.commentsCount }} total
                                     </span>
                                     <SpeakButton
                                         :disabled="speaking"
                                         aria-label="Speak comments count"
                                         icon-class="ri-speak-fill text-lg"
-                                        @click="
-                                            speakActivityStat(
-                                                'profile.stat_comments',
-                                                stats.commentsCount
-                                            )
-                                        "
+                                        @click="speakActivityStat('profile.stat_comments', stats.commentsCount)"
                                     />
                                 </div>
                             </div>
@@ -851,9 +687,7 @@ const speakUserSummary = () => {
                                             :href="replyMessageLink(reply)"
                                             class="inline-flex items-center gap-1 text-sm font-medium text-teal-700 dark:text-teal-400 hover:text-teal-900 dark:hover:text-teal-300 py-1 px-2 -mr-2 rounded transition-colors"
                                         >
-                                            <i
-                                                class="ri-external-link-line text-xs"
-                                            ></i>
+                                            <i class="ri-external-link-line text-xs"></i>
                                             View message
                                         </Link>
                                     </div>
@@ -879,15 +713,11 @@ const speakUserSummary = () => {
                             class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg"
                         >
                             <div class="p-6">
-                                <div
-                                    class="flex items-center justify-between mb-4"
-                                >
+                                <div class="flex items-center justify-between mb-4">
                                     <h3
                                         class="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
                                     >
-                                        <i
-                                            class="ri-reply-line text-teal-700 dark:text-teal-400"
-                                        ></i>
+                                        <i class="ri-reply-line text-teal-700 dark:text-teal-400"></i>
                                         {{ t("profile.replies_to_you") }}
                                     </h3>
                                     <SpeakButton
@@ -904,34 +734,21 @@ const speakUserSummary = () => {
                                         :key="item.id"
                                         class="rounded-lg border border-gray-200 dark:border-gray-700 p-4"
                                     >
-                                        <div
-                                            class="flex items-center justify-between gap-3 mb-2"
-                                        >
-                                            <span
-                                                class="text-xs text-gray-600 dark:text-gray-400"
-                                            >
-                                                {{
-                                                    formatDate(item.created_at)
-                                                }}
+                                        <div class="flex items-center justify-between gap-3 mb-2">
+                                            <span class="text-xs text-gray-600 dark:text-gray-400">
+                                                {{ formatDate(item.created_at) }}
                                             </span>
                                             <Link
                                                 :href="item.href"
                                                 class="inline-flex items-center gap-1 text-sm font-medium text-teal-700 dark:text-teal-400 hover:text-teal-900 dark:hover:text-teal-300 py-1 px-2 -mr-2 rounded transition-colors"
                                             >
-                                                <i
-                                                    class="ri-external-link-line text-xs"
-                                                ></i>
+                                                <i class="ri-external-link-line text-xs"></i>
                                                 View message
                                             </Link>
                                         </div>
-                                        <p
-                                            class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words"
-                                        >
-                                            <span class="font-medium">{{
-                                                item.actorName
-                                            }}</span>
-                                            {{ t("profile.activity_reply") }}:
-                                            {{ item.preview }}
+                                        <p class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+                                            <span class="font-medium">{{ item.actorName }}</span>
+                                            {{ t("profile.activity_reply") }}: {{ item.preview }}
                                         </p>
                                     </div>
                                 </div>
@@ -943,15 +760,11 @@ const speakUserSummary = () => {
                             class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg"
                         >
                             <div class="p-6">
-                                <div
-                                    class="flex items-center justify-between mb-4"
-                                >
+                                <div class="flex items-center justify-between mb-4">
                                     <h3
                                         class="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
                                     >
-                                        <i
-                                            class="ri-notification-3-line text-teal-700 dark:text-teal-400"
-                                        ></i>
+                                        <i class="ri-notification-3-line text-teal-700 dark:text-teal-400"></i>
                                         {{ t("profile.messages_to_you") }}
                                     </h3>
                                     <SpeakButton
@@ -968,34 +781,21 @@ const speakUserSummary = () => {
                                         :key="item.id"
                                         class="rounded-lg border border-gray-200 dark:border-gray-700 p-4"
                                     >
-                                        <div
-                                            class="flex items-center justify-between gap-3 mb-2"
-                                        >
-                                            <span
-                                                class="text-xs text-gray-600 dark:text-gray-400"
-                                            >
-                                                {{
-                                                    formatDate(item.created_at)
-                                                }}
+                                        <div class="flex items-center justify-between gap-3 mb-2">
+                                            <span class="text-xs text-gray-600 dark:text-gray-400">
+                                                {{ formatDate(item.created_at) }}
                                             </span>
                                             <Link
                                                 :href="item.href"
                                                 class="inline-flex items-center gap-1 text-sm font-medium text-teal-700 dark:text-teal-400 hover:text-teal-900 dark:hover:text-teal-300 py-1 px-2 -mr-2 rounded transition-colors"
                                             >
-                                                <i
-                                                    class="ri-external-link-line text-xs"
-                                                ></i>
+                                                <i class="ri-external-link-line text-xs"></i>
                                                 View message
                                             </Link>
                                         </div>
-                                        <p
-                                            class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words"
-                                        >
-                                            <span class="font-medium">{{
-                                                item.actorName
-                                            }}</span>
-                                            {{ t("profile.activity_mention") }}:
-                                            {{ item.preview }}
+                                        <p class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+                                            <span class="font-medium">{{ item.actorName }}</span>
+                                            {{ t("profile.activity_mention") }}: {{ item.preview }}
                                         </p>
                                     </div>
                                 </div>
@@ -1005,10 +805,7 @@ const speakUserSummary = () => {
 
                     <!-- New Books This Week / Recent Uploads -->
                     <div
-                        v-if="
-                            newBooksThisWeek.length > 0 ||
-                            recentUploads.length > 0
-                        "
+                        v-if="newBooksThisWeek.length > 0 || recentUploads.length > 0"
                         class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6"
                     >
                         <div
@@ -1016,15 +813,9 @@ const speakUserSummary = () => {
                             class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg"
                         >
                             <div class="p-6">
-                                <div
-                                    class="flex items-center justify-between mb-4"
-                                >
-                                    <h3
-                                        class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
-                                    >
-                                        <i
-                                            class="ri-book-3-line text-teal-700 dark:text-teal-400"
-                                        ></i>
+                                <div class="flex items-center justify-between mb-4">
+                                    <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                                        <i class="ri-book-3-line text-teal-700 dark:text-teal-400"></i>
                                         {{ t("profile.new_books_this_week") }}
                                     </h3>
                                     <SpeakButton
@@ -1034,9 +825,7 @@ const speakUserSummary = () => {
                                         @click="speakNewBooksThisWeek"
                                     />
                                 </div>
-                                <div
-                                    class="grid grid-cols-1 sm:grid-cols-2 gap-3"
-                                >
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                                     <StatCard
                                         v-for="book in newBooksThisWeek"
                                         :key="book.id"
@@ -1044,14 +833,8 @@ const speakUserSummary = () => {
                                         icon-color="text-teal-700 dark:text-teal-400"
                                         :label="book.title"
                                         :subtitle="formatDate(book.created_at)"
-                                        :href="
-                                            route('books.show', {
-                                                book: book?.slug,
-                                            })
-                                        "
-                                        :cover-image="
-                                            book.cover_image?.media_path
-                                        "
+                                        :href="route('books.show', { book: book?.slug })"
+                                        :cover-image="book.cover_image?.media_path"
                                     />
                                 </div>
                             </div>
@@ -1062,15 +845,9 @@ const speakUserSummary = () => {
                             class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg"
                         >
                             <div class="p-6">
-                                <div
-                                    class="flex items-center justify-between mb-4"
-                                >
-                                    <h3
-                                        class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2"
-                                    >
-                                        <i
-                                            class="ri-image-line text-amber-500 dark:text-amber-400"
-                                        ></i>
+                                <div class="flex items-center justify-between mb-4">
+                                    <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                                        <i class="ri-image-line text-amber-500 dark:text-amber-400"></i>
                                         {{ t("profile.recent_uploads") }}
                                     </h3>
                                     <SpeakButton
@@ -1080,24 +857,15 @@ const speakUserSummary = () => {
                                         @click="speakRecentUploads"
                                     />
                                 </div>
-                                <div
-                                    class="grid grid-cols-1 sm:grid-cols-2 gap-3"
-                                >
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                                     <StatCard
                                         v-for="page in recentUploads"
                                         :key="page.id"
                                         icon="ri-image-line"
                                         icon-color="text-amber-500 dark:text-amber-400"
-                                        :label="
-                                            page.book?.title ??
-                                            t('profile.untitled_book')
-                                        "
+                                        :label="page.book?.title ?? t('profile.untitled_book')"
                                         :subtitle="formatDate(page.created_at)"
-                                        :href="
-                                            route('pages.show', {
-                                                page: page.id,
-                                            })
-                                        "
+                                        :href="route('pages.show', { page: page.id })"
                                         :cover-image="page.media_path"
                                     />
                                 </div>
@@ -1108,6 +876,7 @@ const speakUserSummary = () => {
                     <!-- Admin / preference tools -->
                     <div class="mt-6">
                         <OwnerPanel
+                            :admin-users="adminUsers"
                             :users="users"
                             :site-stats="siteStats"
                             :categories="categories"

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -24,7 +24,8 @@ class DashboardTest extends TestCase
         $response->assertInertia(fn ($page) => $page
             ->component('Users/Show')
             ->where('isOwner', true)
-            ->reloadOnly(['adminSettings', 'categories'])
+            ->has('adminSettings')
+            ->has('categories')
         );
     }
 

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -41,7 +41,9 @@ class UserControllerTest extends TestCase
             ->missing('profileUser.weekly_profile_overview_generated_at')
             ->has('weeklyOverview')
             ->where('weeklyOverview.text', null)
-            ->reloadOnly(['stats', 'recentMessages', 'recentReplies'])
+            ->has('stats')
+            ->has('recentMessages')
+            ->has('recentReplies')
         );
     }
 
@@ -85,11 +87,9 @@ class UserControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertInertia(fn ($page) => $page
-            ->reloadOnly(['stats'], function ($page) {
-                $page->where('stats.totalBooksCount', 3)
-                    ->has('stats.topBooks', 3)
-                    ->has('stats.recentBooks', 3);
-            })
+            ->where('stats.totalBooksCount', 3)
+            ->has('stats.topBooks', 3)
+            ->has('stats.recentBooks', 3)
         );
     }
 
@@ -106,9 +106,7 @@ class UserControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertInertia(fn ($page) => $page
-            ->reloadOnly(['stats'], function ($page) {
-                $page->where('stats.messagesCount', 5);
-            })
+            ->where('stats.messagesCount', 5)
         );
     }
 
@@ -124,9 +122,7 @@ class UserControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertInertia(fn ($page) => $page
-            ->reloadOnly(['recentMessages'], function ($page) {
-                $page->has('recentMessages', 10); // Should only show 10 most recent
-            })
+            ->has('recentMessages', 10) // Should only show 10 most recent
         );
     }
 
@@ -151,10 +147,8 @@ class UserControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertInertia(fn ($page) => $page
-            ->reloadOnly(['stats', 'recentReplies'], function ($page) {
-                $page->where('stats.commentsCount', 12)
-                    ->has('recentReplies', 10);
-            })
+            ->where('stats.commentsCount', 12)
+            ->has('recentReplies', 10)
         );
     }
 


### PR DESCRIPTION
Today's defer->optional migration made almost the entire dashboard's
content (stats, recent activity, uploads, site stats, admin panels)
dependent on a client-side router.reload() succeeding after mount,
instead of being present in the initial page load. Combined with
Cache::forget() invalidation scattered across eight controllers/jobs,
this made the dashboard unreliable in production. Revert
UserController, Show.vue, OwnerPanel.vue, and related cache
invalidation back to the simpler eager-loading approach from before
today's changes.