### PR TITLE
Fix flaky CI failure from leaked world-clock Echo polling timer

### DIFF
--- a/resources/js/Components/ApplicationLogo.test.js
+++ b/resources/js/Components/ApplicationLogo.test.js
@@ -16,6 +16,15 @@ describe("ApplicationLogo", () => {
     beforeEach(() => {
         // Reset any previous wrapper
         wrapper = null;
+
+        // ApplicationLogo pulls in useWorldClockSync, which polls for
+        // window.Echo via a real setTimeout when it's missing. Stub it so
+        // setupEcho() resolves synchronously instead of leaking timers that
+        // fire after this test file's jsdom environment is torn down.
+        window.Echo = {
+            socketId: () => "socket-123",
+            private: () => ({ listen: () => {} }),
+        };
     });
 
     describe("Theme Switching", () => {

--- a/resources/js/Pages/Category/Index.test.js
+++ b/resources/js/Pages/Category/Index.test.js
@@ -46,6 +46,15 @@ describe("Category Index", () => {
     beforeEach(() => {
         vi.clearAllMocks();
 
+        // CategoryIndex renders the real ApplicationLogo, which pulls in
+        // useWorldClockSync. That polls for window.Echo via a real setTimeout
+        // when it's missing, leaking timers that fire after this test file's
+        // jsdom environment is torn down. Stub it so setup resolves synchronously.
+        window.Echo = {
+            socketId: () => "socket-123",
+            private: () => ({ listen: () => {} }),
+        };
+
         // Create proper reactive mock that matches the real useInfiniteScroll behavior
         const mockItems = ref(
             mockBooks.data.map((book) => ({ ...book, loading: false }))


### PR DESCRIPTION
## Summary
- The frontend CI job was failing even though all 421 Vitest tests passed — the failure was an unhandled `ReferenceError: window is not defined`, not a test assertion.
- `ApplicationLogo.test.js` and `Category/Index.test.js` mount the real `ApplicationLogo` component, which calls `useWorldClockSync()` → `setupEcho()`. Without a `window.Echo` stub, `setupEcho()` schedules a real `setTimeout(setupEcho, 500)` retry loop that outlives the test file's synchronous run and fires after jsdom tears down that file's environment, crashing the whole test run.
- Stubbed `window.Echo` in both files' `beforeEach`, matching the pattern already used in `AnalogClock.test.js`, `NotificationList.test.js`, and `useWorldClockSync.test.js`, so `setupEcho()` resolves synchronously instead of leaking a timer.

## Test plan
- [x] `CI=true npm test` — 37 test files / 421 tests passed, no unhandled errors (ran twice to confirm it wasn't a fluke of the timing-dependent leak)
- [x] `npx eslint` on the two changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SHZU1pygwzxAcGXixv1VxA)_