### PR TITLE
Pin message builder input/send button on mobile, icon-only tabs

### DIFF
--- a/resources/js/Components/Messages/MessageBuilder.test.js
+++ b/resources/js/Components/Messages/MessageBuilder.test.js
@@ -89,7 +89,7 @@ describe("MessageBuilder", () => {
 
             const atButton = wrapper
                 .findAll("button")
-                .find((btn) => btn.text().includes("@"));
+                .find((btn) => btn.find("i.ri-at-line").exists());
             expect(atButton).toBeTruthy();
         });
     });

--- a/resources/js/Components/Messages/MessageBuilder.vue
+++ b/resources/js/Components/Messages/MessageBuilder.vue
@@ -997,21 +997,19 @@ defineExpose({
                     type="button"
                     role="tab"
                     :aria-selected="activeCategory === tab.key"
+                    :aria-label="tab.label"
                     :title="tab.label"
                     :class="[
-                        'flex w-16 shrink-0 flex-col items-center gap-1 rounded-lg px-1 py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+                        'flex h-12 w-12 shrink-0 items-center justify-center rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
                         activeCategory === tab.key
                             ? 'bg-white shadow-sm ring-1 ring-gray-200 dark:bg-slate-700 dark:ring-slate-600'
                             : 'hover:bg-white/70 dark:hover:bg-slate-700/60',
                     ]"
                     @click="selectCategory(tab.key)"
                 >
-                    <i :class="[tab.icon, 'text-2xl leading-none', tab.tint]"></i>
-                    <span
-                        class="text-[10px] font-semibold leading-tight text-center text-gray-700 dark:text-gray-200"
-                    >
-                        {{ tab.label }}
-                    </span>
+                    <i
+                        :class="[tab.icon, 'text-2xl leading-none', tab.tint]"
+                    ></i>
                 </button>
             </div>
         </div>
@@ -1025,13 +1023,13 @@ defineExpose({
             <div v-if="activeCategory === 'tools'">
                 <div class="flex items-center gap-2 flex-wrap">
                     <button
-                        class="px-4 py-3 rounded-md bg-blue-600 dark:bg-blue-500 text-white shadow-md hover:bg-blue-700 dark:hover:bg-blue-600 font-bold text-2xl"
+                        class="p-3 rounded-md bg-blue-600 dark:bg-blue-500 text-white shadow-md hover:bg-blue-700 dark:hover:bg-blue-600"
                         type="button"
                         :title="t('builder.tag_user')"
                         :aria-label="t('builder.tag_user_aria')"
                         @click="addWord('@')"
                     >
-                        @
+                        <i class="ri-at-line text-2xl"></i>
                     </button>
                     <button
                         class="p-3 rounded-md bg-slate-700 dark:bg-slate-600 text-white shadow-md hover:bg-slate-600 dark:hover:bg-slate-500"
@@ -1117,7 +1115,9 @@ defineExpose({
                             v-for="(f, i) in favorites"
                             :key="`fav-${i}`"
                             class="flex items-center max-w-full bg-rose-600 rounded-md overflow-hidden"
-                            :class="{ 'ring-2 ring-green-400': justAdded === f }"
+                            :class="{
+                                'ring-2 ring-green-400': justAdded === f,
+                            }"
                         >
                             <button
                                 type="button"

--- a/resources/js/Components/Messages/MessageBuilderModal.vue
+++ b/resources/js/Components/Messages/MessageBuilderModal.vue
@@ -1,6 +1,6 @@
 <template>
     <Modal :show="show" max-width="2xl" @close="$emit('close')">
-        <div class="flex flex-col" style="max-height: 85vh; max-height: 85dvh">
+        <div class="flex flex-col message-builder-sheet">
             <!-- Message Builder: input, category toolbar and the shared content
                  pane. Fills the available height and scrolls internally so the
                  toolbar stays reachable above the on-screen keyboard. -->
@@ -92,3 +92,21 @@ watch(
     { immediate: true }
 );
 </script>
+
+<style scoped>
+/* Desktop: card shrinks to fit its content, capped at 85% of the viewport. */
+.message-builder-sheet {
+    max-height: 85vh;
+    max-height: 85dvh;
+}
+
+/* Mobile: pin the sheet to a fixed height so the input stays stuck to the
+   top, the send button stays stuck to the bottom, and only the category
+   toolbar + word pane in between scrolls. */
+@media (max-width: 639px) {
+    .message-builder-sheet {
+        height: 85vh;
+        height: 85dvh;
+    }
+}
+</style>


### PR DESCRIPTION
Give the message builder sheet a fixed height on mobile so the input
stays stuck to the top and the send button stays stuck to the bottom,
with only the category toolbar + word pane scrolling in between.
Desktop keeps its existing shrink-to-fit sizing.

Also drop the visible text labels from the category tabs (icon-only,
with aria-label/title for accessibility) and replace the literal "@"
tag-user button with the ri-at-line icon.