### PR TITLE
Allow manually-added songs to survive the YouTube playlist sync

### DIFF
--- a/app/Http/Controllers/MusicController.php
+++ b/app/Http/Controllers/MusicController.php
@@ -21,7 +21,8 @@ class MusicController extends Controller
      * Create a new controller instance.
      */
     public function __construct(
-        protected UserTaggingService $userTaggingService
+        protected UserTaggingService $userTaggingService,
+        protected YouTubeService $youTubeService
     ) {
         $this->middleware(function ($request, $next) {
             $musicEnabled = SiteSetting::where('key', 'music_enabled')->first()?->value ?? true;
@@ -101,8 +102,7 @@ class MusicController extends Controller
         $this->authorize('admin');
 
         try {
-            $youTubeService = new YouTubeService;
-            $result = $youTubeService->syncPlaylist();
+            $result = $this->youTubeService->syncPlaylist();
 
             if (! $result['success']) {
                 if (isset($result['quota_exceeded']) && $result['quota_exceeded']) {
@@ -140,11 +140,12 @@ class MusicController extends Controller
         $this->authorize('admin');
 
         try {
-            $youTubeService = new YouTubeService;
-            $result = $youTubeService->removeFromPlaylist($song->youtube_video_id);
+            if (! $song->is_manual) {
+                $result = $this->youTubeService->removeFromPlaylist($song->youtube_video_id);
 
-            if (! $result['success']) {
-                \Log::warning('YouTube playlist removal failed for song '.$song->id.': '.($result['error'] ?? 'Unknown error'));
+                if (! $result['success']) {
+                    \Log::warning('YouTube playlist removal failed for song '.$song->id.': '.($result['error'] ?? 'Unknown error'));
+                }
             }
 
             $song->delete();
@@ -155,6 +156,30 @@ class MusicController extends Controller
 
             return response()->json(['error' => 'Failed to delete song'], 500);
         }
+    }
+
+    /**
+     * Add a song directly by video ID/URL, bypassing the playlist. For videos YouTube
+     * disallows from being added to a playlist but that can still be embedded.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $this->authorize('admin');
+
+        $validated = $request->validate([
+            'youtube_video_id' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $result = $this->youTubeService->addManualSong($validated['youtube_video_id']);
+
+        if (! $result['success']) {
+            return response()->json(['error' => $result['error']], 422);
+        }
+
+        return response()->json([
+            'song' => $result['song'],
+            'warning' => $result['warning'] ?? null,
+        ]);
     }
 
     /**

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -14,6 +14,7 @@ class Song extends Model
 
     protected $fillable = [
         'youtube_video_id',
+        'is_manual',
         'title',
         'description',
         'thumbnail_default',
@@ -30,6 +31,7 @@ class Song extends Model
     protected $casts = [
         'tags' => 'array',
         'published_at' => 'datetime',
+        'is_manual' => 'boolean',
     ];
 
     /**

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -35,6 +35,15 @@ class Song extends Model
     ];
 
     /**
+     * Songs owned by the YouTube playlist sync (i.e. not manually added). Used to keep
+     * the sync's create/update/delete logic from ever touching a manually-added song.
+     */
+    public function scopeSyncManaged(Builder $query): void
+    {
+        $query->where('is_manual', false);
+    }
+
+    /**
      * Scope for filtering songs by title or description (database query)
      * Note: Use Song::search() for Meilisearch-based search via Scout
      */

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -12,7 +12,7 @@ class YouTubeService
 {
     private $apiKey;
 
-    private $playlistId;
+    private ?string $playlistId = null;
 
     private $oauthAccessToken;
 
@@ -22,10 +22,19 @@ class YouTubeService
     {
         $this->apiKey = config('services.youtube.api_key');
         $this->oauthAccessToken = config('services.youtube.oauth_access_token');
+    }
 
-        // Get playlist ID from site settings
-        $playlistIdSetting = SiteSetting::where('key', 'youtube_playlist_id')->first();
-        $this->playlistId = $playlistIdSetting?->value ?: '';
+    /**
+     * Playlist ID from site settings, fetched lazily so instantiating this service
+     * (e.g. via controller DI) doesn't cost a query on requests that never use it.
+     */
+    private function playlistId(): string
+    {
+        if ($this->playlistId === null) {
+            $this->playlistId = SiteSetting::where('key', 'youtube_playlist_id')->first()?->value ?: '';
+        }
+
+        return $this->playlistId;
     }
 
     /**
@@ -33,7 +42,7 @@ class YouTubeService
      */
     public function syncPlaylist()
     {
-        if (! $this->apiKey || ! $this->playlistId) {
+        if (! $this->apiKey || ! $this->playlistId()) {
             return [
                 'success' => false,
                 'error' => 'YouTube API key or playlist ID not configured',
@@ -175,7 +184,7 @@ class YouTubeService
 
         // Find songs whose youtube_video_id is NOT in the current playlist.
         // Manually-added songs are never in the playlist by design, so they're excluded here.
-        $toDelete = Song::where('is_manual', false)->whereNotIn('youtube_video_id', $currentVideoIds)->get();
+        $toDelete = Song::syncManaged()->whereNotIn('youtube_video_id', $currentVideoIds)->get();
 
         $count = 0;
         foreach ($toDelete as $song) {
@@ -202,6 +211,13 @@ class YouTubeService
 
         if (! $existingSong) {
             return false; // New video, don't skip
+        }
+
+        // Manually-added songs are never touched by the sync, even if the video later
+        // appears in the playlist. Checked here (before the batch details fetch) rather
+        // than at write time, so a manual song never costs API quota during sync.
+        if ($existingSong->is_manual) {
+            return true;
         }
 
         // Skip if we have complete data and video hasn't been updated recently
@@ -279,12 +295,6 @@ class YouTubeService
             return false; // Explicitly return false for skipped videos
         }
         $videoId = $snippet['resourceId']['videoId'];
-
-        // Manually-added songs are never touched by the sync, even if the video later
-        // appears in the playlist.
-        if ($existingSong?->is_manual) {
-            return false;
-        }
 
         $songData = [
             'youtube_video_id' => $videoId,
@@ -380,9 +390,8 @@ class YouTubeService
             return $matches[1];
         }
 
-        $trimmed = trim($input);
-        if (preg_match('/^[A-Za-z0-9_-]{11}$/', $trimmed)) {
-            return $trimmed;
+        if (preg_match('/^[A-Za-z0-9_-]{11}$/', trim($input), $matches)) {
+            return $matches[0];
         }
 
         return null;
@@ -465,7 +474,7 @@ class YouTubeService
 
     public function removeFromPlaylist(string $videoId): array
     {
-        if (! $this->apiKey || ! $this->playlistId) {
+        if (! $this->apiKey || ! $this->playlistId()) {
             return [
                 'success' => false,
                 'error' => 'YouTube API key or playlist ID not configured',
@@ -591,7 +600,7 @@ class YouTubeService
     {
         $params = [
             'part' => 'snippet,contentDetails',
-            'playlistId' => $this->playlistId,
+            'playlistId' => $this->playlistId(),
             'maxResults' => 50,
         ];
 

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -173,8 +173,9 @@ class YouTubeService
             return 0;
         }
 
-        // Find songs whose youtube_video_id is NOT in the current playlist
-        $toDelete = Song::whereNotIn('youtube_video_id', $currentVideoIds)->get();
+        // Find songs whose youtube_video_id is NOT in the current playlist.
+        // Manually-added songs are never in the playlist by design, so they're excluded here.
+        $toDelete = Song::where('is_manual', false)->whereNotIn('youtube_video_id', $currentVideoIds)->get();
 
         $count = 0;
         foreach ($toDelete as $song) {
@@ -279,6 +280,12 @@ class YouTubeService
         }
         $videoId = $snippet['resourceId']['videoId'];
 
+        // Manually-added songs are never touched by the sync, even if the video later
+        // appears in the playlist.
+        if ($existingSong?->is_manual) {
+            return false;
+        }
+
         $songData = [
             'youtube_video_id' => $videoId,
             'title' => $snippet['title'],
@@ -291,19 +298,7 @@ class YouTubeService
             $songData = array_merge($songData, $videoDetails);
         }
 
-        // Add thumbnails with fallback URL generation
-        if (isset($snippet['thumbnails'])) {
-            foreach (['default', 'medium', 'high', 'standard', 'maxres'] as $quality) {
-                if (isset($snippet['thumbnails'][$quality])) {
-                    $songData["thumbnail_{$quality}"] = $snippet['thumbnails'][$quality]['url'];
-                }
-            }
-        }
-
-        // Fallback thumbnail URL if none provided
-        if (empty($songData['thumbnail_high'])) {
-            $songData['thumbnail_url'] = "https://img.youtube.com/vi/{$videoId}/hqdefault.jpg";
-        }
+        $songData = array_merge($songData, $this->buildThumbnails($snippet, $videoId));
 
         if ($existingSong) {
             // Build update data, only including fields that have actually changed
@@ -347,6 +342,125 @@ class YouTubeService
         Song::create($songData);
 
         return true; // New song created
+    }
+
+    /**
+     * Build the thumbnail_* fields from a video/playlist-item snippet, falling back to
+     * YouTube's static thumbnail URLs (which always exist) when the API returns none.
+     */
+    private function buildThumbnails(array $snippet, string $videoId): array
+    {
+        $thumbnails = [];
+
+        if (isset($snippet['thumbnails'])) {
+            foreach (['default', 'medium', 'high', 'standard', 'maxres'] as $quality) {
+                if (isset($snippet['thumbnails'][$quality])) {
+                    $thumbnails["thumbnail_{$quality}"] = $snippet['thumbnails'][$quality]['url'];
+                }
+            }
+        }
+
+        if (empty($thumbnails['thumbnail_high'])) {
+            $thumbnails['thumbnail_high'] = "https://img.youtube.com/vi/{$videoId}/hqdefault.jpg";
+        }
+        if (empty($thumbnails['thumbnail_default'])) {
+            $thumbnails['thumbnail_default'] = "https://img.youtube.com/vi/{$videoId}/default.jpg";
+        }
+
+        return $thumbnails;
+    }
+
+    /**
+     * Extract an 11-character YouTube video ID from a bare ID or from the kind of text
+     * YouTube's own Share feature produces (a title, a colon, a URL, trailing punctuation).
+     */
+    public static function parseVideoId(string $input): ?string
+    {
+        if (preg_match('#(?:[?&]v=|youtu\.be/|/shorts/|/embed/|/live/)([A-Za-z0-9_-]{11})#', $input, $matches)) {
+            return $matches[1];
+        }
+
+        $trimmed = trim($input);
+        if (preg_match('/^[A-Za-z0-9_-]{11}$/', $trimmed)) {
+            return $trimmed;
+        }
+
+        return null;
+    }
+
+    /**
+     * Create a Song directly from the YouTube videos API, bypassing the playlist entirely.
+     * Used for videos YouTube disallows from being added to a playlist.
+     */
+    public function addManualSong(string $input): array
+    {
+        $videoId = self::parseVideoId($input);
+
+        if (! $videoId) {
+            return [
+                'success' => false,
+                'error' => 'Not a valid YouTube video ID or URL.',
+            ];
+        }
+
+        if (Song::where('youtube_video_id', $videoId)->exists()) {
+            return [
+                'success' => false,
+                'error' => 'This video has already been added.',
+            ];
+        }
+
+        if (! $this->apiKey) {
+            return [
+                'success' => false,
+                'error' => 'YouTube API key not configured.',
+            ];
+        }
+
+        $response = $this->getWithRetry('https://www.googleapis.com/youtube/v3/videos', [
+            'part' => 'snippet,contentDetails,status',
+            'id' => $videoId,
+            'key' => $this->apiKey,
+        ]);
+
+        if (! $response->successful()) {
+            return $this->handleApiError($response);
+        }
+
+        $data = $response->json();
+        $video = $data['items'][0] ?? null;
+
+        if (! $video) {
+            return [
+                'success' => false,
+                'error' => 'Video not found or is private.',
+            ];
+        }
+
+        $snippet = $video['snippet'];
+
+        $songData = array_merge([
+            'youtube_video_id' => $videoId,
+            'is_manual' => true,
+            'title' => $snippet['title'],
+            'description' => $snippet['description'] ?? null,
+            'published_at' => $snippet['publishedAt'] ?? null,
+            'duration' => $video['contentDetails']['duration'] ?? null,
+            'tags' => isset($snippet['tags']) ? json_encode($snippet['tags']) : null,
+        ], $this->buildThumbnails($snippet, $videoId));
+
+        $song = Song::create($songData);
+
+        $result = [
+            'success' => true,
+            'song' => $song,
+        ];
+
+        if (isset($video['status']['embeddable']) && $video['status']['embeddable'] === false) {
+            $result['warning'] = 'This video has embedding disabled by its owner and may not play in the music player.';
+        }
+
+        return $result;
     }
 
     public function removeFromPlaylist(string $videoId): array

--- a/database/migrations/2026_07_28_000001_add_is_manual_to_songs_table.php
+++ b/database/migrations/2026_07_28_000001_add_is_manual_to_songs_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->boolean('is_manual')->default(false)->index()->after('youtube_video_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropColumn('is_manual');
+        });
+    }
+};

--- a/resources/js/Components/Messages/MessageBuilder.test.js
+++ b/resources/js/Components/Messages/MessageBuilder.test.js
@@ -288,8 +288,12 @@ describe("MessageBuilder", () => {
 
             await nextTick();
 
-            // The "Quick messages" pane is open by default, so its phrases
-            // (e.g. "yes") are visible without switching tabs.
+            // The "Quick messages" pane is opened via its category tab (the
+            // second tab, after "Things you can do") — it is not open by default.
+            const quickTab = wrapper.findAll('[role="tab"]')[1];
+            await quickTab.trigger("click");
+            await nextTick();
+
             const quickButton = wrapper
                 .findAll("button")
                 .find((btn) => btn.text().trim() === "yes");

--- a/resources/js/Components/Music/MusicFlyoutContent.test.js
+++ b/resources/js/Components/Music/MusicFlyoutContent.test.js
@@ -1,0 +1,163 @@
+import MusicFlyoutContent from "@/Components/Music/MusicFlyoutContent.vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
+
+global.route = vi.fn((name, params) => {
+    if (name === "music.destroy" && params != null) {
+        return `/music/${params}`;
+    }
+    return `/${name}`;
+});
+
+const mockCanAdmin = ref(true);
+const mockSetSongsList = vi.fn();
+const mockRemoveSongFromList = vi.fn();
+const mockSetSearch = vi.fn();
+const mockSetFilter = vi.fn();
+
+vi.mock("@/composables/permissions", () => ({
+    usePermissions: () => ({
+        canAdmin: mockCanAdmin,
+    }),
+}));
+
+vi.mock("@/composables/useMusicPlayer", () => ({
+    useMusicPlayer: () => ({
+        currentSong: ref(null),
+        isPlaying: ref(false),
+        playSong: vi.fn(),
+        toggleCurrentSongPlayback: vi.fn(),
+        setSongsList: mockSetSongsList,
+        removeSongFromList: mockRemoveSongFromList,
+        setSearch: mockSetSearch,
+        setFilter: mockSetFilter,
+    }),
+}));
+
+vi.mock("@inertiajs/vue3", () => ({
+    router: {
+        post: vi.fn(),
+    },
+}));
+
+vi.mock("@/composables/useConfirmDialog", () => ({
+    useConfirmDialog: () => ({
+        show: ref(false),
+        message: ref(""),
+        title: ref(""),
+        confirmLabel: ref(""),
+        cancelLabel: ref(""),
+        confirmVariant: ref("primary"),
+        ask: () => Promise.resolve(true),
+        onConfirmed: () => {},
+        onCancelled: () => {},
+    }),
+}));
+
+vi.mock("@/composables/useSpeechSynthesis", () => ({
+    useSpeechSynthesis: () => ({
+        speak: vi.fn(),
+    }),
+}));
+
+vi.mock("@/composables/useTranslations", () => ({
+    useTranslations: () => ({
+        t: (key) => key,
+    }),
+}));
+
+describe("MusicFlyoutContent admin add song", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCanAdmin.value = true;
+
+        document.head.innerHTML =
+            '<meta name="csrf-token" content="test-token" />';
+
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () =>
+                Promise.resolve({
+                    song: { id: 99, title: "New Song", is_manual: true },
+                }),
+        });
+    });
+
+    const mountContent = () =>
+        mount(MusicFlyoutContent, {
+            props: {
+                songs: { data: [], next_page_url: null },
+                search: "",
+                filter: "",
+                scrollRootEl: null,
+            },
+        });
+
+    it("shows the Add button for admins", () => {
+        const wrapper = mountContent();
+
+        const buttons = wrapper.findAll("button").map((b) => b.text());
+        expect(buttons).toContain("Add");
+    });
+
+    it("hides the Add button for non-admins", () => {
+        mockCanAdmin.value = false;
+        const wrapper = mountContent();
+
+        const buttons = wrapper.findAll("button").map((b) => b.text());
+        expect(buttons).not.toContain("Add");
+    });
+
+    it("submits the pasted input to music.store and emits reload on success", async () => {
+        const wrapper = mountContent();
+
+        const addButton = wrapper
+            .findAll("button")
+            .find((b) => b.text() === "Add");
+        await addButton.trigger("click");
+        await nextTick();
+
+        const input = wrapper.find('input[type="text"]');
+        await input.setValue(
+            "Learn Animal Sounds | Moo Cow Song: https://music.youtube.com/watch?v=86IrHVH43mQ&feature=share."
+        );
+        await wrapper.find("form").trigger("submit.prevent");
+        await nextTick();
+        await nextTick();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            "/music.store",
+            expect.objectContaining({ method: "POST" })
+        );
+        expect(wrapper.emitted("reload")).toBeTruthy();
+    });
+
+    it("shows an inline error when the add request fails", async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            json: () =>
+                Promise.resolve({
+                    error: "Not a valid YouTube video ID or URL.",
+                }),
+        });
+
+        const wrapper = mountContent();
+
+        const addButton = wrapper
+            .findAll("button")
+            .find((b) => b.text() === "Add");
+        await addButton.trigger("click");
+        await nextTick();
+
+        await wrapper.find('input[type="text"]').setValue("garbage");
+        await wrapper.find("form").trigger("submit.prevent");
+        await nextTick();
+        await nextTick();
+
+        expect(wrapper.text()).toContain(
+            "Not a valid YouTube video ID or URL."
+        );
+        expect(wrapper.emitted("reload")).toBeFalsy();
+    });
+});

--- a/resources/js/Components/Music/MusicFlyoutContent.vue
+++ b/resources/js/Components/Music/MusicFlyoutContent.vue
@@ -12,16 +12,56 @@
                     {{ title }}
                 </h2>
             </button>
-            <Button
-                v-if="canAdmin"
-                :disabled="syncing"
-                class="text-sm"
-                @click="syncPlaylist"
-            >
-                <span v-if="syncing">Syncing...</span>
-                <span v-else>Sync</span>
-            </Button>
+            <div v-if="canAdmin" class="flex gap-2">
+                <Button
+                    :disabled="syncing"
+                    class="text-sm"
+                    @click="syncPlaylist"
+                >
+                    <span v-if="syncing">Syncing...</span>
+                    <span v-else>Sync</span>
+                </Button>
+                <Button class="text-sm" @click="showAddForm = !showAddForm">
+                    Add
+                </Button>
+            </div>
         </div>
+
+        <!-- Add song form (admin only) -->
+        <form
+            v-if="canAdmin && showAddForm"
+            class="p-4 border-b border-gray-200 dark:border-gray-700 flex flex-col gap-2"
+            @submit.prevent="submitAddSong"
+        >
+            <input
+                v-model="addSongInput"
+                type="text"
+                placeholder="Paste a YouTube link or Share text"
+                class="border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md p-2 text-sm"
+            />
+            <div class="flex items-center gap-2">
+                <Button
+                    type="submit"
+                    :disabled="addingSong || !addSongInput.trim()"
+                    class="text-sm"
+                >
+                    <span v-if="addingSong">Adding...</span>
+                    <span v-else>Add song</span>
+                </Button>
+                <span
+                    v-if="addSongError"
+                    class="text-xs text-red-600 dark:text-red-400"
+                >
+                    {{ addSongError }}
+                </span>
+                <span
+                    v-else-if="addSongWarning"
+                    class="text-xs text-amber-600 dark:text-amber-400"
+                >
+                    {{ addSongWarning }}
+                </span>
+            </div>
+        </form>
 
         <!-- Filters -->
         <div class="p-2 pb-0 flex flex-wrap justify-around">
@@ -150,6 +190,11 @@ const props = defineProps({
 
 const syncing = ref(false);
 const loading = ref(false);
+const showAddForm = ref(false);
+const addSongInput = ref("");
+const addingSong = ref(false);
+const addSongError = ref("");
+const addSongWarning = ref("");
 const infiniteScrollRef = ref(null);
 const headingRef = ref(null);
 const items = ref(
@@ -254,9 +299,10 @@ const playSong = (song) => {
 };
 
 const deleteSong = async (song) => {
-    const ok = await askConfirm(
-        `Delete "${song.title}"? This will also remove it from the YouTube playlist.`
-    );
+    const confirmText = song.is_manual
+        ? `Delete "${song.title}"?`
+        : `Delete "${song.title}"? This will also remove it from the YouTube playlist.`;
+    const ok = await askConfirm(confirmText);
     if (!ok) {
         return;
     }
@@ -306,6 +352,51 @@ const applyFilter = async (filter) => {
     }
 
     loading.value = false;
+};
+
+const submitAddSong = async () => {
+    if (addingSong.value || !addSongInput.value.trim()) return;
+
+    addingSong.value = true;
+    addSongError.value = "";
+    addSongWarning.value = "";
+
+    try {
+        const response = await fetch(route("music.store"), {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-TOKEN": document
+                    .querySelector('meta[name="csrf-token"]')
+                    .getAttribute("content"),
+                Accept: "application/json",
+                "X-Requested-With": "XMLHttpRequest",
+            },
+            body: JSON.stringify({ youtube_video_id: addSongInput.value }),
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            addSongInput.value = "";
+            if (data.warning) {
+                addSongWarning.value = data.warning;
+            } else {
+                showAddForm.value = false;
+            }
+            emit("reload", {
+                filter: props.filter || null,
+                search: props.search || null,
+            });
+        } else {
+            addSongError.value = data.error || "Failed to add song.";
+        }
+    } catch (error) {
+        console.error("Error adding song:", error);
+        addSongError.value = "Failed to add song.";
+    } finally {
+        addingSong.value = false;
+    }
 };
 
 const syncPlaylist = () => {

--- a/resources/js/Components/Music/MusicFlyoutContent.vue
+++ b/resources/js/Components/Music/MusicFlyoutContent.vue
@@ -49,16 +49,15 @@
                     <span v-else>Add song</span>
                 </Button>
                 <span
-                    v-if="addSongError"
-                    class="text-xs text-red-600 dark:text-red-400"
+                    v-if="addSongFeedback"
+                    class="text-xs"
+                    :class="
+                        addSongFeedback.type === 'error'
+                            ? 'text-red-600 dark:text-red-400'
+                            : 'text-amber-600 dark:text-amber-400'
+                    "
                 >
-                    {{ addSongError }}
-                </span>
-                <span
-                    v-else-if="addSongWarning"
-                    class="text-xs text-amber-600 dark:text-amber-400"
-                >
-                    {{ addSongWarning }}
+                    {{ addSongFeedback.text }}
                 </span>
             </div>
         </form>
@@ -193,8 +192,7 @@ const loading = ref(false);
 const showAddForm = ref(false);
 const addSongInput = ref("");
 const addingSong = ref(false);
-const addSongError = ref("");
-const addSongWarning = ref("");
+const addSongFeedback = ref(null); // { type: "error"|"warning", text: string }
 const infiniteScrollRef = ref(null);
 const headingRef = ref(null);
 const items = ref(
@@ -287,6 +285,20 @@ watch(
     }
 );
 
+const fetchWithCsrf = (url, options = {}) =>
+    fetch(url, {
+        ...options,
+        headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-TOKEN": document
+                .querySelector('meta[name="csrf-token"]')
+                .getAttribute("content"),
+            Accept: "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+            ...options.headers,
+        },
+    });
+
 const playSong = (song) => {
     if (currentSong.value && currentSong.value.id === song.id) {
         toggleCurrentSongPlayback();
@@ -308,16 +320,8 @@ const deleteSong = async (song) => {
     }
 
     try {
-        const response = await fetch(route("music.destroy", song.id), {
+        const response = await fetchWithCsrf(route("music.destroy", song.id), {
             method: "DELETE",
-            headers: {
-                "Content-Type": "application/json",
-                "X-CSRF-TOKEN": document
-                    .querySelector('meta[name="csrf-token"]')
-                    .getAttribute("content"),
-                Accept: "application/json",
-                "X-Requested-With": "XMLHttpRequest",
-            },
         });
 
         if (response.ok) {
@@ -358,20 +362,11 @@ const submitAddSong = async () => {
     if (addingSong.value || !addSongInput.value.trim()) return;
 
     addingSong.value = true;
-    addSongError.value = "";
-    addSongWarning.value = "";
+    addSongFeedback.value = null;
 
     try {
-        const response = await fetch(route("music.store"), {
+        const response = await fetchWithCsrf(route("music.store"), {
             method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "X-CSRF-TOKEN": document
-                    .querySelector('meta[name="csrf-token"]')
-                    .getAttribute("content"),
-                Accept: "application/json",
-                "X-Requested-With": "XMLHttpRequest",
-            },
             body: JSON.stringify({ youtube_video_id: addSongInput.value }),
         });
 
@@ -380,7 +375,7 @@ const submitAddSong = async () => {
         if (response.ok) {
             addSongInput.value = "";
             if (data.warning) {
-                addSongWarning.value = data.warning;
+                addSongFeedback.value = { type: "warning", text: data.warning };
             } else {
                 showAddForm.value = false;
             }
@@ -389,11 +384,14 @@ const submitAddSong = async () => {
                 search: props.search || null,
             });
         } else {
-            addSongError.value = data.error || "Failed to add song.";
+            addSongFeedback.value = {
+                type: "error",
+                text: data.error || "Failed to add song.",
+            };
         }
     } catch (error) {
         console.error("Error adding song:", error);
-        addSongError.value = "Failed to add song.";
+        addSongFeedback.value = { type: "error", text: "Failed to add song." };
     } finally {
         addingSong.value = false;
     }

--- a/resources/js/Components/Music/SongListItem.test.js
+++ b/resources/js/Components/Music/SongListItem.test.js
@@ -194,6 +194,30 @@ describe("SongListItem", () => {
         expect(playButton.classes()).toContain("hover:bg-green-700");
     });
 
+    it("shows a manual badge for manually-added songs", () => {
+        wrapper = mount(SongListItem, {
+            props: {
+                song: { ...mockSong, is_manual: true },
+                currentSong: null,
+                isPlaying: false,
+            },
+        });
+
+        expect(wrapper.text()).toContain("manual");
+    });
+
+    it("does not show a manual badge for synced songs", () => {
+        wrapper = mount(SongListItem, {
+            props: {
+                song: { ...mockSong, is_manual: false },
+                currentSong: null,
+                isPlaying: false,
+            },
+        });
+
+        expect(wrapper.text()).not.toContain("manual");
+    });
+
     it("uses thumbnail_default when provided", () => {
         wrapper = mount(SongListItem, {
             props: {

--- a/resources/js/Components/Music/SongListItem.vue
+++ b/resources/js/Components/Music/SongListItem.vue
@@ -28,6 +28,13 @@
                 class="text-base font-medium text-gray-900 dark:text-gray-100 truncate mb-1"
             >
                 {{ song.title }}
+                <span
+                    v-if="song.is_manual"
+                    class="ml-1 align-middle text-[10px] font-semibold uppercase text-amber-600 dark:text-amber-400"
+                    title="Added manually; not managed by YouTube sync"
+                >
+                    manual
+                </span>
             </h3>
             <div
                 class="flex items-center text-xs text-gray-500 dark:text-gray-400 space-x-4"

--- a/routes/web.php
+++ b/routes/web.php
@@ -160,6 +160,7 @@ Route::middleware('auth')->group(function () {
         Route::post('/collages/{collage}/generate-pdf', [CollageController::class, 'generatePdf'])->name('collages.generate-pdf');
 
         Route::post('/music/sync', [MusicController::class, 'sync'])->name('music.sync');
+        Route::post('/music', [MusicController::class, 'store'])->name('music.store');
         Route::delete('/music/{song}', [MusicController::class, 'destroy'])->name('music.destroy');
 
         Route::put('/admin/permissions', [AdminController::class, 'update'])->name('admin.permissions');

--- a/tests/Feature/MusicTest.php
+++ b/tests/Feature/MusicTest.php
@@ -310,6 +310,72 @@ class MusicTest extends TestCase
         ]);
     }
 
+    public function test_regular_user_cannot_add_song(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->post(route('music.store'), ['youtube_video_id' => 'abcdefghijk']);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_add_manual_song(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        $mock = $this->createMock(YouTubeService::class);
+        $mock->method('addManualSong')
+            ->with('abcdefghijk')
+            ->willReturn([
+                'success' => true,
+                'song' => Song::factory()->make(['youtube_video_id' => 'abcdefghijk', 'is_manual' => true]),
+            ]);
+        $this->app->instance(YouTubeService::class, $mock);
+
+        $response = $this->post(route('music.store'), ['youtube_video_id' => 'abcdefghijk']);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['song']);
+    }
+
+    public function test_add_manual_song_returns_error_response_on_failure(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        $mock = $this->createMock(YouTubeService::class);
+        $mock->method('addManualSong')
+            ->willReturn([
+                'success' => false,
+                'error' => 'Not a valid YouTube video ID or URL.',
+            ]);
+        $this->app->instance(YouTubeService::class, $mock);
+
+        $response = $this->post(route('music.store'), ['youtube_video_id' => 'garbage']);
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Not a valid YouTube video ID or URL.']);
+    }
+
+    public function test_deleting_manual_song_does_not_call_playlist_removal(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        $song = Song::factory()->create(['is_manual' => true]);
+
+        $mock = $this->createMock(YouTubeService::class);
+        $mock->expects($this->never())->method('removeFromPlaylist');
+        $this->app->instance(YouTubeService::class, $mock);
+
+        $response = $this->delete(route('music.destroy', $song));
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('songs', ['id' => $song->id]);
+    }
+
     /**
      * Mock the YouTube service to avoid actual API calls during testing
      */

--- a/tests/Feature/YouTubeServiceTest.php
+++ b/tests/Feature/YouTubeServiceTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SiteSetting;
+use App\Models\Song;
+use App\Services\YouTubeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class YouTubeServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.youtube.api_key' => 'test-api-key']);
+        SiteSetting::updateOrCreate(['key' => 'youtube_playlist_id'], ['value' => 'PL_test_playlist']);
+    }
+
+    private function playlistItemsResponse(array $videoIds): array
+    {
+        return [
+            'items' => array_map(fn ($id) => [
+                'id' => 'playlist-item-'.$id,
+                'snippet' => [
+                    'resourceId' => ['videoId' => $id],
+                    'title' => 'Video '.$id,
+                    'description' => 'Description for '.$id,
+                    'publishedAt' => '2024-01-01T00:00:00Z',
+                    'thumbnails' => [
+                        'default' => ['url' => "https://img.example/{$id}/default.jpg"],
+                        'high' => ['url' => "https://img.example/{$id}/high.jpg"],
+                    ],
+                ],
+            ], $videoIds),
+        ];
+    }
+
+    private function videoDetailsResponse(array $videoIds): array
+    {
+        return [
+            'items' => array_map(fn ($id) => [
+                'id' => $id,
+                'contentDetails' => ['duration' => 'PT3M0S'],
+                'snippet' => [
+                    'publishedAt' => '2024-01-01T00:00:00Z',
+                    'tags' => ['tag-a', 'tag-b'],
+                ],
+            ], $videoIds),
+        ];
+    }
+
+    public function test_sync_deletes_song_missing_from_playlist(): void
+    {
+        $staleSong = Song::factory()->create(['youtube_video_id' => 'staleVideoId']);
+        // Already fully synced (duration + tags set) so the sync skips re-fetching it and
+        // the playlistItems/videos fakes below only need to cover the surviving video.
+        $survivingSong = Song::factory()->create(['youtube_video_id' => 'survivingVideoId']);
+
+        Http::fake([
+            'https://www.googleapis.com/youtube/v3/playlistItems*' => Http::response($this->playlistItemsResponse(['survivingVideoId'])),
+        ]);
+
+        (new YouTubeService)->syncPlaylist();
+
+        $this->assertDatabaseMissing('songs', ['id' => $staleSong->id]);
+        $this->assertDatabaseHas('songs', ['id' => $survivingSong->id]);
+    }
+
+    public function test_sync_does_not_delete_manual_song_missing_from_playlist(): void
+    {
+        $manualSong = Song::factory()->create([
+            'youtube_video_id' => 'manualVideoId',
+            'is_manual' => true,
+        ]);
+        $survivingSong = Song::factory()->create(['youtube_video_id' => 'survivingVideoId']);
+
+        Http::fake([
+            'https://www.googleapis.com/youtube/v3/playlistItems*' => Http::response($this->playlistItemsResponse(['survivingVideoId'])),
+        ]);
+
+        $result = (new YouTubeService)->syncPlaylist();
+
+        $this->assertTrue($result['success']);
+        $this->assertDatabaseHas('songs', ['id' => $manualSong->id]);
+        $this->assertDatabaseHas('songs', ['id' => $survivingSong->id]);
+    }
+
+    public function test_sync_does_not_overwrite_manual_song_that_appears_in_playlist(): void
+    {
+        $manualSong = Song::factory()->create([
+            'youtube_video_id' => 'manualVideoId',
+            'is_manual' => true,
+            'title' => 'My Custom Title',
+        ]);
+
+        Http::fake([
+            'https://www.googleapis.com/youtube/v3/playlistItems*' => Http::response($this->playlistItemsResponse(['manualVideoId'])),
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response($this->videoDetailsResponse(['manualVideoId'])),
+        ]);
+
+        (new YouTubeService)->syncPlaylist();
+
+        $manualSong->refresh();
+        $this->assertSame('My Custom Title', $manualSong->title);
+        $this->assertTrue($manualSong->is_manual);
+    }
+
+    public function test_add_manual_song_creates_song_from_video_id(): void
+    {
+        Http::fake([
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response([
+                'items' => [[
+                    'id' => 'abcdefghijk',
+                    'snippet' => [
+                        'title' => 'Manually Added Song',
+                        'description' => 'A disallowed-from-playlist video',
+                        'publishedAt' => '2024-05-01T00:00:00Z',
+                        'thumbnails' => [
+                            'default' => ['url' => 'https://img.example/abcdefghijk/default.jpg'],
+                            'high' => ['url' => 'https://img.example/abcdefghijk/high.jpg'],
+                        ],
+                        'tags' => ['tag-a'],
+                    ],
+                    'contentDetails' => ['duration' => 'PT2M30S'],
+                    'status' => ['embeddable' => true],
+                ]],
+            ]),
+        ]);
+
+        $result = (new YouTubeService)->addManualSong('abcdefghijk');
+
+        $this->assertTrue($result['success']);
+        $this->assertArrayNotHasKey('warning', $result);
+        $this->assertDatabaseHas('songs', [
+            'youtube_video_id' => 'abcdefghijk',
+            'title' => 'Manually Added Song',
+            'is_manual' => true,
+            'duration' => 'PT2M30S',
+        ]);
+    }
+
+    public function test_add_manual_song_parses_share_text(): void
+    {
+        Http::fake([
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response([
+                'items' => [[
+                    'id' => '86IrHVH43mQ',
+                    'snippet' => [
+                        'title' => 'Learn Animal Sounds',
+                        'description' => 'desc',
+                        'publishedAt' => '2024-05-01T00:00:00Z',
+                    ],
+                    'contentDetails' => ['duration' => 'PT1M0S'],
+                    'status' => ['embeddable' => true],
+                ]],
+            ]),
+        ]);
+
+        $shareText = 'Learn Animal Sounds | Moo Cow Song | Learn Animals: https://music.youtube.com/watch?v=86IrHVH43mQ&feature=share.';
+
+        $result = (new YouTubeService)->addManualSong($shareText);
+
+        $this->assertTrue($result['success']);
+        $this->assertDatabaseHas('songs', ['youtube_video_id' => '86IrHVH43mQ']);
+    }
+
+    public function test_add_manual_song_flags_non_embeddable_video(): void
+    {
+        Http::fake([
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response([
+                'items' => [[
+                    'id' => 'abcdefghijk',
+                    'snippet' => [
+                        'title' => 'Blocked Embed Video',
+                        'description' => 'desc',
+                        'publishedAt' => '2024-05-01T00:00:00Z',
+                    ],
+                    'contentDetails' => ['duration' => 'PT1M0S'],
+                    'status' => ['embeddable' => false],
+                ]],
+            ]),
+        ]);
+
+        $result = (new YouTubeService)->addManualSong('abcdefghijk');
+
+        $this->assertTrue($result['success']);
+        $this->assertArrayHasKey('warning', $result);
+    }
+
+    public function test_add_manual_song_rejects_invalid_input(): void
+    {
+        $result = (new YouTubeService)->addManualSong('not a youtube link at all');
+
+        $this->assertFalse($result['success']);
+        $this->assertDatabaseCount('songs', 0);
+    }
+
+    public function test_add_manual_song_rejects_duplicate_video(): void
+    {
+        Song::factory()->create(['youtube_video_id' => 'abcdefghijk']);
+
+        $result = (new YouTubeService)->addManualSong('abcdefghijk');
+
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_parse_video_id_handles_various_inputs(): void
+    {
+        $shareText = 'Learn Animal Sounds | Moo Cow Song | Learn Animals: https://music.youtube.com/watch?v=86IrHVH43mQ&feature=share.';
+
+        $this->assertSame('86IrHVH43mQ', YouTubeService::parseVideoId($shareText));
+        $this->assertSame('abcdefghijk', YouTubeService::parseVideoId('abcdefghijk'));
+        $this->assertSame('abcdefghijk', YouTubeService::parseVideoId('https://youtu.be/abcdefghijk'));
+        $this->assertSame('abcdefghijk', YouTubeService::parseVideoId('https://www.youtube.com/shorts/abcdefghijk'));
+        $this->assertNull(YouTubeService::parseVideoId('https://example.com/not-youtube'));
+        $this->assertNull(YouTubeService::parseVideoId('too short'));
+    }
+}

--- a/tests/Feature/YouTubeServiceTest.php
+++ b/tests/Feature/YouTubeServiceTest.php
@@ -54,6 +54,25 @@ class YouTubeServiceTest extends TestCase
         ];
     }
 
+    /**
+     * Single-video "videos" API response, as consumed by addManualSong().
+     */
+    private function videoResponse(string $id, array $overrides = []): array
+    {
+        return [
+            'items' => [array_replace_recursive([
+                'id' => $id,
+                'snippet' => [
+                    'title' => 'Manually Added Song',
+                    'description' => 'desc',
+                    'publishedAt' => '2024-05-01T00:00:00Z',
+                ],
+                'contentDetails' => ['duration' => 'PT2M30S'],
+                'status' => ['embeddable' => true],
+            ], $overrides)],
+        ];
+    }
+
     public function test_sync_deletes_song_missing_from_playlist(): void
     {
         $staleSong = Song::factory()->create(['youtube_video_id' => 'staleVideoId']);
@@ -113,23 +132,16 @@ class YouTubeServiceTest extends TestCase
     public function test_add_manual_song_creates_song_from_video_id(): void
     {
         Http::fake([
-            'https://www.googleapis.com/youtube/v3/videos*' => Http::response([
-                'items' => [[
-                    'id' => 'abcdefghijk',
-                    'snippet' => [
-                        'title' => 'Manually Added Song',
-                        'description' => 'A disallowed-from-playlist video',
-                        'publishedAt' => '2024-05-01T00:00:00Z',
-                        'thumbnails' => [
-                            'default' => ['url' => 'https://img.example/abcdefghijk/default.jpg'],
-                            'high' => ['url' => 'https://img.example/abcdefghijk/high.jpg'],
-                        ],
-                        'tags' => ['tag-a'],
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response($this->videoResponse('abcdefghijk', [
+                'snippet' => [
+                    'description' => 'A disallowed-from-playlist video',
+                    'thumbnails' => [
+                        'default' => ['url' => 'https://img.example/abcdefghijk/default.jpg'],
+                        'high' => ['url' => 'https://img.example/abcdefghijk/high.jpg'],
                     ],
-                    'contentDetails' => ['duration' => 'PT2M30S'],
-                    'status' => ['embeddable' => true],
-                ]],
-            ]),
+                    'tags' => ['tag-a'],
+                ],
+            ])),
         ]);
 
         $result = (new YouTubeService)->addManualSong('abcdefghijk');
@@ -147,18 +159,9 @@ class YouTubeServiceTest extends TestCase
     public function test_add_manual_song_parses_share_text(): void
     {
         Http::fake([
-            'https://www.googleapis.com/youtube/v3/videos*' => Http::response([
-                'items' => [[
-                    'id' => '86IrHVH43mQ',
-                    'snippet' => [
-                        'title' => 'Learn Animal Sounds',
-                        'description' => 'desc',
-                        'publishedAt' => '2024-05-01T00:00:00Z',
-                    ],
-                    'contentDetails' => ['duration' => 'PT1M0S'],
-                    'status' => ['embeddable' => true],
-                ]],
-            ]),
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response(
+                $this->videoResponse('86IrHVH43mQ', ['snippet' => ['title' => 'Learn Animal Sounds']])
+            ),
         ]);
 
         $shareText = 'Learn Animal Sounds | Moo Cow Song | Learn Animals: https://music.youtube.com/watch?v=86IrHVH43mQ&feature=share.';
@@ -172,18 +175,10 @@ class YouTubeServiceTest extends TestCase
     public function test_add_manual_song_flags_non_embeddable_video(): void
     {
         Http::fake([
-            'https://www.googleapis.com/youtube/v3/videos*' => Http::response([
-                'items' => [[
-                    'id' => 'abcdefghijk',
-                    'snippet' => [
-                        'title' => 'Blocked Embed Video',
-                        'description' => 'desc',
-                        'publishedAt' => '2024-05-01T00:00:00Z',
-                    ],
-                    'contentDetails' => ['duration' => 'PT1M0S'],
-                    'status' => ['embeddable' => false],
-                ]],
-            ]),
+            'https://www.googleapis.com/youtube/v3/videos*' => Http::response($this->videoResponse('abcdefghijk', [
+                'snippet' => ['title' => 'Blocked Embed Video'],
+                'status' => ['embeddable' => false],
+            ])),
         ]);
 
         $result = (new YouTubeService)->addManualSong('abcdefghijk');


### PR DESCRIPTION
Some YouTube videos can't be added to a playlist, so they never made it
into the songs table. Admins can now paste a YouTube link/share text or
bare video ID into the music flyout to add a song directly via the
YouTube videos API. Manual songs are flagged with is_manual and are
excluded from the sync's delete pass and never overwritten by it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017as2ii12FVN9BXeJrD7QgB