### PR TITLE
Fix blank buttons in the unblock confirm dialog

### DIFF
--- a/resources/js/Components/ConfirmDialog.test.js
+++ b/resources/js/Components/ConfirmDialog.test.js
@@ -1,0 +1,46 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import ConfirmDialog from "./ConfirmDialog.vue";
+
+const mountDialog = (props = {}) =>
+    mount(ConfirmDialog, {
+        props: { show: true, message: "Are you sure?", ...props },
+        global: {
+            stubs: {
+                Modal: {
+                    template: "<div><slot /></div>",
+                },
+                teleport: true,
+            },
+        },
+    });
+
+describe("ConfirmDialog", () => {
+    it("renders labels for both buttons when none are passed", () => {
+        const wrapper = mountDialog();
+        const buttons = wrapper.findAll("button");
+
+        expect(buttons).toHaveLength(2);
+        buttons.forEach((button) => {
+            expect(button.text().trim()).not.toBe("");
+        });
+    });
+
+    it("uses the provided labels when they are passed", () => {
+        const wrapper = mountDialog({
+            confirmLabel: "Unblock",
+            cancelLabel: "Never mind",
+        });
+        const buttons = wrapper.findAll("button");
+
+        expect(buttons[0].text()).toBe("Never mind");
+        expect(buttons[1].text()).toBe("Unblock");
+    });
+
+    it("labels the danger confirm button too", () => {
+        const wrapper = mountDialog({ confirmVariant: "danger" });
+        const buttons = wrapper.findAll("button");
+
+        expect(buttons[1].text().trim()).not.toBe("");
+    });
+});

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -3,7 +3,10 @@ import Button from "@/Components/Button.vue";
 import DangerButton from "@/Components/DangerButton.vue";
 import Modal from "@/Components/Modal.vue";
 import SecondaryButton from "@/Components/SecondaryButton.vue";
+import { useTranslations } from "@/composables/useTranslations";
 import { computed, getCurrentInstance, useSlots } from "vue";
+
+const { t } = useTranslations();
 
 const instance = getCurrentInstance();
 const dialogUid = instance?.uid ?? 0;
@@ -57,6 +60,14 @@ const hasFooterSlot = computed(() => !!slots.footer);
 const showTitleRegion = computed(() => props.title || hasTitleSlot.value);
 const showBodyRegion = computed(() => props.message || hasDefaultSlot.value);
 
+// Callers may omit the labels; never render an empty button.
+const resolvedConfirmLabel = computed(
+    () => props.confirmLabel || t("common.ok")
+);
+const resolvedCancelLabel = computed(
+    () => props.cancelLabel || t("common.cancel")
+);
+
 function onDismiss() {
     emit("update:show", false);
     emit("cancel");
@@ -106,17 +117,17 @@ function onConfirm() {
             </div>
             <div v-else class="mt-6 flex justify-end gap-3">
                 <SecondaryButton type="button" @click="onDismiss">
-                    <slot name="cancelButton">{{ cancelLabel }}</slot>
+                    <slot name="cancelButton">{{ resolvedCancelLabel }}</slot>
                 </SecondaryButton>
                 <DangerButton
                     v-if="confirmVariant === 'danger'"
                     type="button"
                     @click="onConfirm"
                 >
-                    <slot name="confirmButton">{{ confirmLabel }}</slot>
+                    <slot name="confirmButton">{{ resolvedConfirmLabel }}</slot>
                 </DangerButton>
                 <Button v-else type="button" @click="onConfirm">
-                    <slot name="confirmButton">{{ confirmLabel }}</slot>
+                    <slot name="confirmButton">{{ resolvedConfirmLabel }}</slot>
                 </Button>
             </div>
         </div>


### PR DESCRIPTION
ConfirmDialog's confirmLabel/cancelLabel default to an empty string, so
any call site that omits them renders two unlabeled buttons. The unblock
all pages/sounds dialog on Users/Show is the one place that omits both.

Fall back to the translated common.ok / common.cancel labels inside
ConfirmDialog so the buttons always have text, and cover it with tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QWf9NQmo1Di6VC5fqG8WRF