### PR TITLE
Generate AI descriptions for uploaded images and videos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ FORWARD_MEILISEARCH_PORT=7700
 HUGGINGFACE_API_TOKEN=
 HUGGINGFACE_USER_OVERVIEW_MODEL=Qwen/Qwen2.5-1.5B-Instruct
 HUGGINGFACE_USER_OVERVIEW_ENDPOINT=https://router.huggingface.co/featherless-ai/v1/chat/completions
+HUGGINGFACE_VISION_MODEL=Qwen/Qwen2.5-VL-72B-Instruct
+HUGGINGFACE_VISION_ENDPOINT=https://router.huggingface.co/v1/chat/completions
 
 TMDB_API_KEY=
 TMDB_BASE_API_URL=https://api.themoviedb.org/3

--- a/app/Jobs/StoreImage.php
+++ b/app/Jobs/StoreImage.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Book;
 use App\Models\Page;
+use App\Services\MediaDescriptionService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -17,6 +18,13 @@ use Intervention\Image\Laravel\Facades\Image;
 class StoreImage implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Generating a description calls an external model, so allow more than the
+     * 60s queue default -- but stay under the queues' retry_after of 90s, or a
+     * still-running job gets re-reserved and the upload is written twice.
+     */
+    public int $timeout = 85;
 
     protected string $filePath;
 
@@ -58,7 +66,7 @@ class StoreImage implements ShouldQueue
     /**
      * Execute the job.
      */
-    public function handle(): void
+    public function handle(MediaDescriptionService $descriptions): void
     {
         $disk = str_starts_with($this->filePath, 's3://') ? 's3' : 'local';
         $filePath = str_replace('s3://', '', $this->filePath);
@@ -80,11 +88,14 @@ class StoreImage implements ShouldQueue
         try {
             $imageData = Storage::disk($disk)->get($filePath);
             file_put_contents($tempFile, $imageData);
+            unset($imageData);
 
             $image = Image::decode($tempFile);
             $encoded = $image->encode(new WebpEncoder(30, true));
             Storage::disk('s3')->put($this->path, (string) $encoded);
             Storage::disk('s3')->setVisibility($this->path, 'public');
+
+            $page = null;
 
             if ($this->page) {
                 $this->page->update([
@@ -94,6 +105,8 @@ class StoreImage implements ShouldQueue
                     'latitude' => $this->latitude,
                     'longitude' => $this->longitude,
                 ]);
+
+                $page = $this->page;
             } elseif ($this->book) {
                 $page = $this->book->pages()->create([
                     'content' => $this->content,
@@ -105,6 +118,27 @@ class StoreImage implements ShouldQueue
 
                 if (! $this->book->cover_page) {
                     $this->book->update(['cover_page' => $page->id]);
+                }
+            }
+
+            // Caption last, so the page and its media are already visible while
+            // the model runs. This never throws, so a slow or failing model
+            // costs nothing. $image is safe to downscale here: the stored webp
+            // was encoded above and nothing reads $image after this point.
+            if ($page) {
+                try {
+                    $caption = $descriptions->resolveCaption($this->content, $image);
+
+                    if ($caption !== $this->content) {
+                        $page->update(['content' => $caption]);
+                    }
+                } catch (\Throwable $captionError) {
+                    // The media and the page are already stored, so a caption
+                    // problem must not fail an upload that otherwise succeeded.
+                    Log::warning('Failed to caption image after StoreImage', [
+                        'page_id' => $page->id,
+                        'exception' => $captionError->getMessage(),
+                    ]);
                 }
             }
 

--- a/app/Jobs/StoreVideo.php
+++ b/app/Jobs/StoreVideo.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Book;
 use App\Models\Page;
+use App\Services\MediaDescriptionService;
 use Aws\S3\Exception\S3Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -74,7 +75,7 @@ class StoreVideo implements ShouldQueue
         $this->longitude = $longitude;
     }
 
-    public function handle(): void
+    public function handle(MediaDescriptionService $descriptions): void
     {
         $shouldDeleteSourceFile = false;
 
@@ -382,7 +383,7 @@ class StoreVideo implements ShouldQueue
                 }
 
                 // Use database transaction for data consistency
-                DB::transaction(function () use ($processedFilePath, $posterPath) {
+                $page = DB::transaction(function () use ($processedFilePath, $posterPath) {
                     if ($this->page) {
                         $this->page->update([
                             'content' => $this->content,
@@ -392,7 +393,11 @@ class StoreVideo implements ShouldQueue
                             'latitude' => $this->latitude,
                             'longitude' => $this->longitude,
                         ]);
-                    } elseif ($this->book) {
+
+                        return $this->page;
+                    }
+
+                    if ($this->book) {
                         $page = $this->book->pages()->create([
                             'content' => $this->content,
                             'media_path' => $processedFilePath,
@@ -406,8 +411,33 @@ class StoreVideo implements ShouldQueue
                         if (! $this->book->cover_page) {
                             $this->book->update(['cover_page' => $page->id]);
                         }
+
+                        return $page;
                     }
+
+                    return null;
                 });
+
+                // Describe the poster frame that becomes the page's cover, once
+                // the page is already saved and visible. This never throws, so a
+                // slow or failing model costs nothing.
+                // $screenshotContents is false when file_get_contents failed.
+                if ($page && $screenshotContents) {
+                    try {
+                        $caption = $descriptions->resolveCaption($this->content, $screenshotContents);
+
+                        if ($caption !== $this->content) {
+                            $page->update(['content' => $caption]);
+                        }
+                    } catch (Throwable $captionError) {
+                        // The video and the page are already stored, so a caption
+                        // problem must not retry a 30-minute job and duplicate them.
+                        Log::warning('Failed to caption video poster after StoreVideo', [
+                            'page_id' => $page->id,
+                            'exception' => $captionError->getMessage(),
+                        ]);
+                    }
+                }
 
                 // After successful DB update, delete any old media/poster
                 try {

--- a/app/Services/MediaDescriptionService.php
+++ b/app/Services/MediaDescriptionService.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SiteSetting;
+use App\Support\Content;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Laravel\Facades\Image;
+
+/**
+ * Describes an uploaded image in one short sentence using a vision-language
+ * model on the Hugging Face Inference Providers router.
+ *
+ * Every failure mode returns null: callers use the description only when the
+ * uploader left the caption blank, so a missing one is never an error.
+ */
+class MediaDescriptionService
+{
+    private const MAX_TOKENS = 60;
+
+    private const TEMPERATURE = 0.2;
+
+    private const CONNECT_TIMEOUT_SECONDS = 5;
+
+    /**
+     * Kept deliberately short: the whole job has to finish inside the queue's
+     * retry_after (90s), or the worker re-reserves a job that is still running
+     * and the upload is written twice.
+     */
+    private const REQUEST_TIMEOUT_SECONDS = 15;
+
+    private const RETRY_TIMES = 2;
+
+    private const RETRY_SLEEP_MS = 1000;
+
+    private const MIN_DESCRIPTION_LENGTH = 10;
+
+    /** Longest edge sent to the model; keeps the base64 payload small. */
+    private const MAX_EDGE_PIXELS = 1024;
+
+    private const JPEG_QUALITY = 85;
+
+    private const SYSTEM_PROMPT = 'Write one short, plain sentence describing what is in this photo. '
+        .'No preamble, no markdown, no lists, no quotes. '
+        .'Do not guess names of people. Do not mention that it is a photo or image.';
+
+    private ?bool $enabled = null;
+
+    /**
+     * The caption a page should be saved with.
+     *
+     * Returns $existingContent untouched whenever the uploader typed anything,
+     * and never throws: a failed description just leaves the caption as-is.
+     *
+     * @param  string|ImageInterface|null  $source  Image bytes, or an image the
+     *                                              caller already decoded. It is
+     *                                              downscaled in place, so pass a
+     *                                              decoded image only once you are
+     *                                              done with it.
+     */
+    public function resolveCaption(?string $existingContent, string|ImageInterface|null $source): ?string
+    {
+        if (! Content::isBlank($existingContent) || $source === null || $source === '') {
+            return $existingContent;
+        }
+
+        if (! $this->isEnabled()) {
+            return $existingContent;
+        }
+
+        $prepared = $this->toJpeg($source);
+        $description = $prepared === null ? null : $this->describe($prepared);
+
+        if ($description === null) {
+            return $existingContent;
+        }
+
+        // ENT_NOQUOTES, not e(): this is text content, not an attribute value,
+        // and escaping quotes would leak "&#039;" into speech synthesis, page
+        // titles and the Meilisearch index, none of which decode entities.
+        return '<p>'.htmlspecialchars($description, ENT_NOQUOTES, 'UTF-8').'</p>';
+    }
+
+    /**
+     * @param  string  $imageBytes  JPEG bytes of an already-downscaled image.
+     */
+    public function describe(string $imageBytes): ?string
+    {
+        if (! $this->isEnabled()) {
+            return null;
+        }
+
+        $token = config('services.huggingface.api_token');
+
+        if (! is_string($token) || trim($token) === '') {
+            Log::warning('Media description skipped: missing Hugging Face token');
+
+            return null;
+        }
+
+        try {
+            $response = Http::withToken($token)
+                ->connectTimeout(self::CONNECT_TIMEOUT_SECONDS)
+                ->timeout(self::REQUEST_TIMEOUT_SECONDS)
+                ->retry(self::RETRY_TIMES, self::RETRY_SLEEP_MS, function ($exception): bool {
+                    if ($exception instanceof ConnectionException) {
+                        return true;
+                    }
+                    if ($exception instanceof RequestException && $exception->response) {
+                        return $exception->response->serverError() || $exception->response->status() === 429;
+                    }
+
+                    return false;
+                }, false)
+                ->post((string) config('services.huggingface.vision_endpoint'), [
+                    'model' => (string) config('services.huggingface.vision_model'),
+                    'max_tokens' => self::MAX_TOKENS,
+                    'temperature' => self::TEMPERATURE,
+                    'messages' => [
+                        ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
+                        ['role' => 'user', 'content' => [
+                            ['type' => 'text', 'text' => 'Describe this image.'],
+                            ['type' => 'image_url', 'image_url' => [
+                                'url' => 'data:image/jpeg;base64,'.base64_encode($imageBytes),
+                            ]],
+                        ]],
+                    ],
+                ]);
+
+            if (! $response->successful()) {
+                Log::warning('Media description generation failed', [
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+
+                return null;
+            }
+
+            $description = $this->normalize(
+                (string) data_get($response->json(), 'choices.0.message.content', '')
+            );
+
+            if ($description === null) {
+                Log::warning('Media description generation returned unusable content', [
+                    'body' => $response->body(),
+                ]);
+            }
+
+            return $description;
+        } catch (\Throwable $exception) {
+            Log::warning('Media description generation exception', [
+                'error' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Downscale to MAX_EDGE_PIXELS and re-encode as JPEG so the base64 payload
+     * stays small and the format is one every vision model accepts.
+     */
+    private function toJpeg(string|ImageInterface $source): ?string
+    {
+        try {
+            $image = $source instanceof ImageInterface ? $source : Image::decode($source);
+
+            return (string) $image
+                ->scaleDown(self::MAX_EDGE_PIXELS, self::MAX_EDGE_PIXELS)
+                ->encode(new JpegEncoder(self::JPEG_QUALITY));
+        } catch (\Throwable $exception) {
+            Log::warning('Media description image preparation failed', [
+                'error' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    private function isEnabled(): bool
+    {
+        return $this->enabled ??= (bool) SiteSetting::where('key', 'ai_descriptions_enabled')->first()?->value;
+    }
+
+    /**
+     * Strip the wrapping the model sometimes adds and reject anything that is
+     * not a plain sentence.
+     */
+    private function normalize(string $text): ?string
+    {
+        $text = trim($text, " \t\n\r\0\x0B\"'`");
+
+        if (preg_match('/^#|\n#|```|\*\*/', $text)) {
+            return null;
+        }
+
+        if (mb_strlen($text) < self::MIN_DESCRIPTION_LENGTH) {
+            return null;
+        }
+
+        return $text;
+    }
+}

--- a/app/Support/Content.php
+++ b/app/Support/Content.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Helpers for the rich-text HTML stored in Page::$content.
+ */
+final class Content
+{
+    /**
+     * Whether the given rich text holds no actual words.
+     *
+     * The editor leaves markup behind even when the user typed nothing, so
+     * "<p></p>", "<p><br></p>" and "<p>&nbsp;</p>" all count as blank.
+     */
+    public static function isBlank(?string $html): bool
+    {
+        $text = html_entity_decode(strip_tags((string) $html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // trim() alone leaves the non-breaking space that &nbsp; decodes to.
+        return preg_replace('/[\s\x{00A0}]+/u', '', $text) === '';
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,8 @@ return [
         'api_token' => env('HUGGINGFACE_API_TOKEN'),
         'user_overview_model' => env('HUGGINGFACE_USER_OVERVIEW_MODEL', 'Qwen/Qwen2.5-1.5B-Instruct'),
         'user_overview_endpoint' => env('HUGGINGFACE_USER_OVERVIEW_ENDPOINT', 'https://router.huggingface.co/featherless-ai/v1/chat/completions'),
+        'vision_model' => env('HUGGINGFACE_VISION_MODEL', 'Qwen/Qwen2.5-VL-72B-Instruct'),
+        'vision_endpoint' => env('HUGGINGFACE_VISION_ENDPOINT', 'https://router.huggingface.co/v1/chat/completions'),
     ],
 
     'tmdb' => [

--- a/database/migrations/2026_08_23_000001_add_ai_descriptions_setting.php
+++ b/database/migrations/2026_08_23_000001_add_ai_descriptions_setting.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('site_settings')->insert([
+            'key' => 'ai_descriptions_enabled',
+            'value' => '0',
+            'type' => 'boolean',
+            'description' => 'Generate AI descriptions for uploaded images and videos (sends uploads to a third-party AI service)',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('site_settings')->where('key', 'ai_descriptions_enabled')->delete();
+    }
+};

--- a/tests/Feature/MediaDescriptionServiceTest.php
+++ b/tests/Feature/MediaDescriptionServiceTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SiteSetting;
+use App\Services\MediaDescriptionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Laravel\Facades\Image;
+use Tests\TestCase;
+
+class MediaDescriptionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = 'https://router.huggingface.co/v1/chat/completions';
+
+    private const MODEL = 'Qwen/Qwen2.5-VL-72B-Instruct';
+
+    private function configureService(bool $enabled = true, ?string $token = 'test-token'): void
+    {
+        config([
+            'services.huggingface.api_token' => $token,
+            'services.huggingface.vision_endpoint' => self::ENDPOINT,
+            'services.huggingface.vision_model' => self::MODEL,
+        ]);
+
+        SiteSetting::updateOrCreate(
+            ['key' => 'ai_descriptions_enabled'],
+            ['value' => $enabled ? '1' : '0', 'type' => 'boolean']
+        );
+    }
+
+    private function imageBytes(int $width = 40, int $height = 30): string
+    {
+        return (string) Image::createImage($width, $height)->encode(new JpegEncoder(85));
+    }
+
+    private function fakeResponse(string $content): void
+    {
+        Http::fake([
+            'router.huggingface.co/*' => Http::response([
+                'choices' => [['message' => ['content' => $content]]],
+            ], 200),
+        ]);
+    }
+
+    private function service(): MediaDescriptionService
+    {
+        return app(MediaDescriptionService::class);
+    }
+
+    public function test_it_returns_the_generated_sentence(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('A small dog sleeping on a blue couch.');
+
+        $this->assertSame(
+            'A small dog sleeping on a blue couch.',
+            $this->service()->describe($this->imageBytes())
+        );
+    }
+
+    public function test_it_sends_the_image_as_a_base64_data_url(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('A small dog sleeping on a blue couch.');
+
+        $this->service()->describe($this->imageBytes());
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === self::ENDPOINT
+                && $request->hasHeader('Authorization', 'Bearer test-token')
+                && data_get($request->data(), 'model') === self::MODEL
+                && data_get($request->data(), 'messages.0.role') === 'system'
+                && data_get($request->data(), 'messages.1.content.0.type') === 'text'
+                && data_get($request->data(), 'messages.1.content.1.type') === 'image_url'
+                && str_starts_with(
+                    (string) data_get($request->data(), 'messages.1.content.1.image_url.url'),
+                    'data:image/jpeg;base64,'
+                );
+        });
+    }
+
+    public function test_it_strips_wrapping_quotes(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('"A small dog sleeping on a blue couch."');
+
+        $this->assertSame(
+            'A small dog sleeping on a blue couch.',
+            $this->service()->describe($this->imageBytes())
+        );
+    }
+
+    public function test_it_skips_the_request_entirely_when_the_setting_is_off(): void
+    {
+        $this->configureService(enabled: false);
+        Http::fake();
+
+        $this->assertNull($this->service()->describe($this->imageBytes()));
+
+        Http::assertNothingSent();
+    }
+
+    public function test_it_skips_the_request_when_the_token_is_missing(): void
+    {
+        $this->configureService(token: '');
+        Http::fake();
+
+        $this->assertNull($this->service()->describe($this->imageBytes()));
+
+        Http::assertNothingSent();
+    }
+
+    public function test_it_returns_null_on_an_error_response(): void
+    {
+        $this->configureService();
+        Http::fake(['router.huggingface.co/*' => Http::response(['error' => 'bad request'], 400)]);
+
+        $this->assertNull($this->service()->describe($this->imageBytes()));
+    }
+
+    public function test_it_returns_null_on_a_connection_exception(): void
+    {
+        $this->configureService();
+        Http::fake(['router.huggingface.co/*' => fn () => throw new ConnectionException('timed out')]);
+
+        $this->assertNull($this->service()->describe($this->imageBytes()));
+    }
+
+    public function test_it_rejects_empty_short_and_markdown_content(): void
+    {
+        $this->configureService();
+
+        foreach (['', 'A dog.', '## A small dog sleeping on a couch', '**A small dog on a couch**'] as $content) {
+            $this->fakeResponse($content);
+
+            $this->assertNull(
+                $this->service()->describe($this->imageBytes()),
+                "Expected null for content: {$content}"
+            );
+        }
+    }
+
+    public function test_resolve_caption_wraps_the_description_in_a_paragraph(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('A small dog sleeping on a blue couch.');
+
+        $this->assertSame(
+            '<p>A small dog sleeping on a blue couch.</p>',
+            $this->service()->resolveCaption('<p><br></p>', $this->imageBytes())
+        );
+    }
+
+    public function test_resolve_caption_escapes_markup_in_the_description(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('A sign reading <b>Open</b> & ready.');
+
+        $this->assertSame(
+            '<p>A sign reading &lt;b&gt;Open&lt;/b&gt; &amp; ready.</p>',
+            $this->service()->resolveCaption(null, $this->imageBytes())
+        );
+    }
+
+    public function test_resolve_caption_leaves_apostrophes_readable(): void
+    {
+        $this->configureService();
+        $this->fakeResponse("A child's toy on the floor.");
+
+        // Entities here would be read aloud verbatim by speech synthesis and
+        // indexed into Meilisearch, since neither decodes them.
+        $this->assertSame(
+            "<p>A child's toy on the floor.</p>",
+            $this->service()->resolveCaption(null, $this->imageBytes())
+        );
+    }
+
+    public function test_resolve_caption_ignores_a_false_source(): void
+    {
+        $this->configureService();
+        Http::fake();
+
+        // file_get_contents() returns false, which reaches this untyped.
+        $this->assertNull($this->service()->resolveCaption(null, false));
+
+        Http::assertNothingSent();
+    }
+
+    public function test_resolve_caption_never_overwrites_text_the_user_typed(): void
+    {
+        $this->configureService();
+        Http::fake();
+
+        $this->assertSame(
+            '<p>My own caption</p>',
+            $this->service()->resolveCaption('<p>My own caption</p>', $this->imageBytes())
+        );
+
+        Http::assertNothingSent();
+    }
+
+    public function test_resolve_caption_keeps_existing_content_when_generation_fails(): void
+    {
+        $this->configureService();
+        Http::fake(['router.huggingface.co/*' => Http::response([], 500)]);
+
+        $this->assertSame('<p><br></p>', $this->service()->resolveCaption('<p><br></p>', $this->imageBytes()));
+    }
+
+    public function test_resolve_caption_keeps_existing_content_when_the_image_is_undecodable(): void
+    {
+        $this->configureService();
+        Http::fake();
+
+        $this->assertNull($this->service()->resolveCaption(null, 'not an image'));
+
+        Http::assertNothingSent();
+    }
+}

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -13,9 +13,12 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class PagesTest extends TestCase
@@ -293,6 +296,118 @@ class PagesTest extends TestCase
         $this->assertSame($page->content, $payload['content']);
 
         $response->assertRedirect(route('books.show', $book));
+    }
+
+    private function enableAiDescriptions(): void
+    {
+        config([
+            'services.huggingface.api_token' => 'test-token',
+            'services.huggingface.vision_endpoint' => 'https://router.huggingface.co/v1/chat/completions',
+            'services.huggingface.vision_model' => 'Qwen/Qwen2.5-VL-72B-Instruct',
+        ]);
+
+        SiteSetting::updateOrCreate(
+            ['key' => 'ai_descriptions_enabled'],
+            ['value' => '1', 'type' => 'boolean']
+        );
+    }
+
+    private function bookAsEditor(): Book
+    {
+        Storage::fake('s3');
+
+        $this->actingAs($user = User::factory()->create());
+        $user->givePermissionTo('edit pages');
+
+        return Book::factory()->create();
+    }
+
+    private function fakeDescription(string $description): void
+    {
+        Http::fake([
+            'router.huggingface.co/*' => Http::response([
+                'choices' => [['message' => ['content' => $description]]],
+            ], 200),
+        ]);
+    }
+
+    private function storeImagePage(Book $book, ?string $content, ?UploadedFile $image = null): TestResponse
+    {
+        $payload = [
+            'book_id' => $book->id,
+            'image' => $image ?? UploadedFile::fake()->image('photo1.jpg'),
+        ];
+
+        if ($content !== null) {
+            $payload['content'] = $content;
+        }
+
+        return $this->post(route('pages.store'), $payload);
+    }
+
+    /**
+     * @return array<string, array{0: string|null}>
+     */
+    public static function blankContentProvider(): array
+    {
+        return [
+            'no content field' => [null],
+            'only empty markup' => ['<p><br></p>'],
+        ];
+    }
+
+    #[DataProvider('blankContentProvider')]
+    public function test_blank_content_is_replaced_with_an_ai_description(?string $content): void
+    {
+        $book = $this->bookAsEditor();
+        $this->enableAiDescriptions();
+        $this->fakeDescription('A small dog sleeping on a blue couch.');
+
+        $this->storeImagePage($book, $content);
+
+        $this->assertSame(
+            '<p>A small dog sleeping on a blue couch.</p>',
+            Book::find($book->id)->pages->first()->content
+        );
+    }
+
+    public function test_content_the_user_typed_is_never_replaced(): void
+    {
+        $book = $this->bookAsEditor();
+        $this->enableAiDescriptions();
+        Http::fake();
+
+        $this->storeImagePage($book, '<p>My own caption</p>');
+
+        $this->assertSame('<p>My own caption</p>', Book::find($book->id)->pages->first()->content);
+        Http::assertNothingSent();
+    }
+
+    public function test_upload_still_succeeds_when_description_generation_fails(): void
+    {
+        $book = $this->bookAsEditor();
+        $this->enableAiDescriptions();
+        Http::fake(['router.huggingface.co/*' => Http::response([], 500)]);
+
+        $image = UploadedFile::fake()->image('photo1.jpg');
+
+        $this->storeImagePage($book, null, $image)
+            ->assertRedirect(route('books.show', $book));
+
+        Storage::disk('s3')->assertExists(
+            'books/'.$book->slug.'/'.pathinfo($image->hashName(), PATHINFO_FILENAME).'.webp'
+        );
+        $this->assertNotNull(Book::find($book->id)->pages->first());
+    }
+
+    public function test_no_description_is_requested_when_the_setting_is_off(): void
+    {
+        $book = $this->bookAsEditor();
+        Http::fake();
+
+        $this->storeImagePage($book, null);
+
+        Http::assertNothingSent();
     }
 
     public function test_page_cannot_be_updated_without_permissions()

--- a/tests/Unit/ContentTest.php
+++ b/tests/Unit/ContentTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Content;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ContentTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string|null}>
+     */
+    public static function blankProvider(): array
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'whitespace' => ["  \n\t "],
+            'empty paragraph' => ['<p></p>'],
+            'paragraph with break' => ['<p><br></p>'],
+            'paragraph with nbsp entity' => ['<p>&nbsp;</p>'],
+            'paragraph with raw nbsp' => ["<p>\u{00A0}</p>"],
+            'paragraph with space' => ['<p> </p>'],
+            'nested empty markup' => ['<p><strong><em></em></strong></p>'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function notBlankProvider(): array
+    {
+        return [
+            'plain text' => ['no tags'],
+            'paragraph' => ['<p>hi</p>'],
+            'nested markup' => ['<p><strong>a</strong></p>'],
+            'entity text' => ['<p>&amp;</p>'],
+            'text among empty tags' => ['<p><br></p><p>words</p>'],
+        ];
+    }
+
+    #[DataProvider('blankProvider')]
+    public function test_it_treats_text_free_html_as_blank(?string $html): void
+    {
+        $this->assertTrue(Content::isBlank($html));
+    }
+
+    #[DataProvider('notBlankProvider')]
+    public function test_it_treats_html_containing_words_as_not_blank(string $html): void
+    {
+        $this->assertFalse(Content::isBlank($html));
+    }
+}


### PR DESCRIPTION
## What

Pages whose caption is left blank now get a one-sentence description generated from the media itself, so they have something to display, read aloud via `useSpeechSynthesis`, and index in Meilisearch (`Page::toSearchableArray` indexes `content`).

- **Images** — `StoreImage` describes the uploaded image.
- **Videos** — `StoreVideo` describes the poster frame that becomes the page's cover.

Following [`isAdamBailey/face-value`](https://github.com/isAdamBailey/face-value), this is a **single vision-language model call** to the Hugging Face Inference Providers router's OpenAI-compatible `/chat/completions` endpoint, with the image as a base64 data URL. A VLM returns prose directly, so the keyword-model → sentence-model two-step isn't needed. Reuses the pattern already established by `UserWeeklyOverviewService`.

## Storage: never overwrites a user

The caption goes into the existing `content` column — **no new column** — and only when that column holds no actual words. `content` is rich HTML, and the editor leaves markup behind even when nothing was typed, so `App\Support\Content::isBlank` treats `<p></p>`, `<p><br></p>` and `<p>&nbsp;</p>` as empty (plain `trim()` misses the non-breaking space that `&nbsp;` decodes to). Anything a user actually typed is left untouched.

## Safety

- **Off by default.** New `ai_descriptions_enabled` SiteSetting, appearing automatically on the admin Settings page via the generic `SettingsController`. Also skips silently when `HUGGINGFACE_API_TOKEN` is unset.
- **Enabling it sends uploads to a third-party inference provider** — stated in the setting's description.
- **Never breaks an upload.** The media and the page row are written *first*; the description follows as a narrow `update(['content' => ...])`. Every failure path returns the original caption, and each caption block has its own `try/catch` so a hiccup can't fail a job whose media already succeeded.
- **Queue-safe.** `StoreImage`'s timeout is 85s, deliberately under the queues' `retry_after` of 90s — above it, a still-running job gets re-reserved and the upload is written twice. The vision budget (15s request, 2 attempts) is sized to fit inside that.
- Escapes with `ENT_NOQUOTES`, not `e()` — this is text content, not an attribute, and escaped quotes would leak `&#039;` into speech synthesis, page titles and the search index, none of which decode entities.

## Verified live

Real calls against the model with a generated test image:

```
CAPTION:              '<p>A red circle on a white background.</p>'
user text preserved:  '<p>My caption</p>'
<p>&nbsp;</p> blank:  '<p>A red circle on a white background.</p>'
```

`sail test`: **565 passed** (2698 assertions). `npm run test:run`: **481 passed**. Pint clean.

## Note on model choice

The default is `Qwen/Qwen2.5-VL-72B-Instruct`. The smaller `7B` variant is **not served** by the router — worth re-checking with `curl https://router.huggingface.co/v1/models` if captions ever stop appearing, since an unavailable model fails quietly by design (logs a warning, keeps the blank caption).

## Deploy

Requires `migrate` (inserts the setting row, off). `HUGGINGFACE_VISION_MODEL` / `HUGGINGFACE_VISION_ENDPOINT` are optional — both have working defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p2J9KW5fEAtNyPP3eK8AQ