### PR TITLE
Gate weekly profile overviews behind the AI descriptions setting

### DIFF
--- a/app/Services/MediaDescriptionService.php
+++ b/app/Services/MediaDescriptionService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Models\SiteSetting;
+use App\Support\AiFeature;
 use App\Support\Content;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
@@ -184,7 +184,7 @@ class MediaDescriptionService
 
     private function isEnabled(): bool
     {
-        return $this->enabled ??= (bool) SiteSetting::where('key', 'ai_descriptions_enabled')->first()?->value;
+        return $this->enabled ??= AiFeature::enabled();
     }
 
     /**

--- a/app/Services/UserWeeklyOverviewService.php
+++ b/app/Services/UserWeeklyOverviewService.php
@@ -8,6 +8,7 @@ use App\Models\Message;
 use App\Models\MessageComment;
 use App\Models\MessageReaction;
 use App\Models\User;
+use App\Support\AiFeature;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
@@ -27,6 +28,8 @@ class UserWeeklyOverviewService
 
     private const GENERATION_ATTEMPTS = 3;
 
+    private ?bool $aiEnabled = null;
+
     public function __construct(
         private PopularityService $popularityService
     ) {}
@@ -40,6 +43,11 @@ class UserWeeklyOverviewService
     {
         $metrics = $this->buildMetrics($user);
         $fallbackOverview = $this->buildFallbackOverview($user, $metrics);
+
+        if (! $this->aiEnabled()) {
+            return $fallbackOverview;
+        }
+
         $token = config('services.huggingface.api_token');
 
         if (! is_string($token) || trim($token) === '') {
@@ -63,6 +71,15 @@ class UserWeeklyOverviewService
         }
 
         return $fallbackOverview;
+    }
+
+    /**
+     * Every third-party AI call sits behind the same site setting, so the
+     * overview falls back to the locally built summary when it is off.
+     */
+    private function aiEnabled(): bool
+    {
+        return $this->aiEnabled ??= AiFeature::enabled();
     }
 
     private function attemptGeneration(User $user, string $token, string $endpoint, string $model, string $prompt, int $attempt): ?string

--- a/app/Support/AiFeature.php
+++ b/app/Support/AiFeature.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\SiteSetting;
+
+/**
+ * Single gate for every third-party AI call the app makes: media
+ * descriptions and the weekly profile overviews.
+ */
+class AiFeature
+{
+    public const SETTING_KEY = 'ai_descriptions_enabled';
+
+    public static function enabled(): bool
+    {
+        return (bool) SiteSetting::where('key', self::SETTING_KEY)->first()?->value;
+    }
+}

--- a/tests/Feature/Console/GenerateWeeklyUserOverviewsTest.php
+++ b/tests/Feature/Console/GenerateWeeklyUserOverviewsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Console;
 
+use App\Models\SiteSetting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\ConnectionException;
@@ -24,6 +25,16 @@ class GenerateWeeklyUserOverviewsTest extends TestCase
             'services.huggingface.user_overview_endpoint' => self::ENDPOINT,
             'services.huggingface.user_overview_model' => self::MODEL,
         ]);
+
+        $this->setAiDescriptionsEnabled(true);
+    }
+
+    private function setAiDescriptionsEnabled(bool $enabled): void
+    {
+        SiteSetting::updateOrCreate(
+            ['key' => 'ai_descriptions_enabled'],
+            ['value' => $enabled ? '1' : '0', 'type' => 'boolean']
+        );
     }
 
     public function test_command_saves_generated_overview_on_success(): void
@@ -140,6 +151,7 @@ class GenerateWeeklyUserOverviewsTest extends TestCase
             'services.huggingface.user_overview_endpoint' => self::ENDPOINT,
             'services.huggingface.user_overview_model' => self::MODEL,
         ]);
+        $this->setAiDescriptionsEnabled(true);
 
         $user = User::factory()->create(['name' => 'Tokenless Reader']);
 
@@ -295,5 +307,24 @@ class GenerateWeeklyUserOverviewsTest extends TestCase
             $user->weekly_profile_overview
         );
         $this->assertGreaterThanOrEqual(2, $callCount);
+    }
+
+    public function test_command_saves_fallback_overview_without_calling_ai_when_setting_is_disabled(): void
+    {
+        $this->configureService();
+        $this->setAiDescriptionsEnabled(false);
+
+        $user = User::factory()->create(['name' => 'Quiet Reader']);
+
+        Http::fake();
+
+        $this->artisan('users:generate-weekly-overviews')
+            ->assertExitCode(0);
+
+        $user->refresh();
+
+        $this->assertStringContainsString('Quiet Reader is', $user->weekly_profile_overview);
+        $this->assertNotNull($user->weekly_profile_overview_generated_at);
+        Http::assertNothingSent();
     }
 }

--- a/tests/Feature/Console/SendWeeklyStatsMailTest.php
+++ b/tests/Feature/Console/SendWeeklyStatsMailTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Console;
 
 use App\Mail\WeeklyStatsMail;
 use App\Models\Book;
+use App\Models\SiteSetting;
 use App\Models\SiteStatistic;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -158,6 +159,11 @@ class SendWeeklyStatsMailTest extends TestCase
             'services.huggingface.user_overview_endpoint' => 'https://router.huggingface.co/featherless-ai/v1/chat/completions',
             'services.huggingface.user_overview_model' => 'Qwen/Qwen2.5-1.5B-Instruct',
         ]);
+
+        SiteSetting::updateOrCreate(
+            ['key' => 'ai_descriptions_enabled'],
+            ['value' => '1', 'type' => 'boolean']
+        );
 
         Http::fake([
             'router.huggingface.co/*' => function (Request $request) use ($overviewsByName) {


### PR DESCRIPTION
Move the ai_descriptions_enabled lookup into a shared AiFeature gate and apply it to the weekly overview generation too, so every third-party AI call sits behind one setting. When it is off, overviews fall back to the locally built summary and no request is made.


Claude-Session: https://claude.ai/code/session_013p2J9KW5fEAtNyPP3eK8AQ