### PR TITLE
Generate AI descriptions for video snapshots

### DIFF
--- a/app/Jobs/CreateVideoSnapshot.php
+++ b/app/Jobs/CreateVideoSnapshot.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Book;
 use App\Models\User;
+use App\Services\MediaDescriptionService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -92,7 +93,7 @@ class CreateVideoSnapshot implements ShouldQueue
         return [60, 120, 240];
     }
 
-    public function handle(): void
+    public function handle(MediaDescriptionService $descriptions): void
     {
         // Validate that models still exist
         if (! $this->book->exists || ! $this->user->exists) {
@@ -334,6 +335,20 @@ class CreateVideoSnapshot implements ShouldQueue
                     }
                 }
 
+                // Describe the frame before the local copy goes away. The
+                // attribution line below is kept underneath the description,
+                // and a failing model just leaves the attribution on its own.
+                $content = "<p><strong>{$this->user->name}</strong> took this screenshot from <strong><a href='/pages/{$this->pageId}'>this video</a></strong>.</p>";
+
+                try {
+                    $content = $descriptions->prependDescription($content, file_get_contents($fullImagePath) ?: null);
+                } catch (\Throwable $captionError) {
+                    Log::warning('Failed to describe video snapshot', [
+                        'page_id' => $this->pageId,
+                        'exception' => $captionError->getMessage(),
+                    ]);
+                }
+
                 // Dispatch StoreImage job (StoreImage will remove its S3 source on success)
                 try {
                     StoreImage::dispatch('s3://'.$tempS3Path, $mediaPath);
@@ -380,10 +395,10 @@ class CreateVideoSnapshot implements ShouldQueue
                 }
 
                 // Only create database entry after successful S3 upload and job dispatch
-                DB::transaction(function () use ($mediaPath) {
+                DB::transaction(function () use ($mediaPath, $content) {
                     // Create the page first
                     $page = $this->book->pages()->create([
-                        'content' => "<p><strong>{$this->user->name}</strong> took this screenshot from <strong><a href='/pages/{$this->pageId}'>this video</a></strong>.</p>",
+                        'content' => $content,
                         'media_path' => $mediaPath,
                     ]);
 

--- a/app/Services/MediaDescriptionService.php
+++ b/app/Services/MediaDescriptionService.php
@@ -65,19 +65,53 @@ class MediaDescriptionService
      */
     public function resolveCaption(?string $existingContent, string|ImageInterface|null $source): ?string
     {
-        if (! Content::isBlank($existingContent) || $source === null || $source === '') {
+        if (! Content::isBlank($existingContent)) {
             return $existingContent;
         }
 
-        if (! $this->isEnabled()) {
-            return $existingContent;
+        return $this->describeAsParagraph($source) ?? $existingContent;
+    }
+
+    /**
+     * The caption for media the app itself already captioned, such as the
+     * attribution line on a video snapshot.
+     *
+     * The generated sentence goes first and $existingContent is kept after it,
+     * so the description reads as the caption and the existing text as a note
+     * under it. Never throws: a failed description leaves the content as-is.
+     *
+     * @param  string|ImageInterface|null  $source  Image bytes, or an image the
+     *                                              caller already decoded. It is
+     *                                              downscaled in place, so pass a
+     *                                              decoded image only once you are
+     *                                              done with it.
+     */
+    public function prependDescription(?string $existingContent, string|ImageInterface|null $source): ?string
+    {
+        if (Content::isBlank($existingContent)) {
+            return $this->resolveCaption($existingContent, $source);
+        }
+
+        $paragraph = $this->describeAsParagraph($source);
+
+        return $paragraph === null ? $existingContent : $paragraph.$existingContent;
+    }
+
+    /**
+     * The description of $source as a single HTML paragraph, or null whenever
+     * one could not be produced.
+     */
+    private function describeAsParagraph(string|ImageInterface|null $source): ?string
+    {
+        if ($source === null || $source === '' || ! $this->isEnabled()) {
+            return null;
         }
 
         $prepared = $this->toJpeg($source);
         $description = $prepared === null ? null : $this->describe($prepared);
 
         if ($description === null) {
-            return $existingContent;
+            return null;
         }
 
         // ENT_NOQUOTES, not e(): this is text content, not an attribute value,

--- a/tests/Feature/MediaDescriptionServiceTest.php
+++ b/tests/Feature/MediaDescriptionServiceTest.php
@@ -222,4 +222,50 @@ class MediaDescriptionServiceTest extends TestCase
 
         Http::assertNothingSent();
     }
+
+    public function test_prepend_description_keeps_the_existing_content_underneath(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('A small dog sleeping on a blue couch.');
+
+        $this->assertSame(
+            '<p>A small dog sleeping on a blue couch.</p><p>Alex took this screenshot.</p>',
+            $this->service()->prependDescription('<p>Alex took this screenshot.</p>', $this->imageBytes())
+        );
+    }
+
+    public function test_prepend_description_keeps_the_existing_content_when_generation_fails(): void
+    {
+        $this->configureService();
+        Http::fake(['router.huggingface.co/*' => Http::response([], 500)]);
+
+        $this->assertSame(
+            '<p>Alex took this screenshot.</p>',
+            $this->service()->prependDescription('<p>Alex took this screenshot.</p>', $this->imageBytes())
+        );
+    }
+
+    public function test_prepend_description_is_skipped_when_disabled(): void
+    {
+        $this->configureService(enabled: false);
+        Http::fake();
+
+        $this->assertSame(
+            '<p>Alex took this screenshot.</p>',
+            $this->service()->prependDescription('<p>Alex took this screenshot.</p>', $this->imageBytes())
+        );
+
+        Http::assertNothingSent();
+    }
+
+    public function test_prepend_description_replaces_blank_existing_content(): void
+    {
+        $this->configureService();
+        $this->fakeResponse('A small dog sleeping on a blue couch.');
+
+        $this->assertSame(
+            '<p>A small dog sleeping on a blue couch.</p>',
+            $this->service()->prependDescription('<p><br></p>', $this->imageBytes())
+        );
+    }
 }


### PR DESCRIPTION
Snapshot pages are created with an attribution line already in their content ("**Adam** took this screenshot from **this video**."), so `resolveCaption()` — which only fills a blank caption — left them alone and they never got an AI description.

## Changes

- **`MediaDescriptionService`**: extracted the shared generate-and-wrap logic into `describeAsParagraph()`, and added `prependDescription()`, which puts the generated sentence *above* content the app itself wrote. Blank existing content behaves exactly like `resolveCaption()`; a disabled feature flag, a failed model call, or an undecodable image returns the existing content unchanged.
- **`CreateVideoSnapshot`**: describes the extracted frame while it is still on local disk (after the S3 upload, before cleanup), wrapped in its own try/catch so a caption failure can't fail the snapshot. The page is then created with the combined content.

Resulting page content:

```html
<p>A small dog sleeping on a blue couch.</p>
<p><strong>Adam</strong> took this screenshot from <strong><a href='/pages/12'>this video</a></strong>.</p>
```

## Tests

Four new cases in `MediaDescriptionServiceTest` cover prepend, generation failure, the feature flag being off, and blank existing content. Full suite: 581 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p2J9KW5fEAtNyPP3eK8AQ